### PR TITLE
bradesco: change wallet to 26

### DIFF
--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -31,7 +31,7 @@ export const buildPayload = boleto =>
     .then(merchantId => ({
       merchant_id: always(merchantId),
       boleto: {
-        carteira: always('25'),
+        carteira: always('26'),
         nosso_numero: prop('title_id'),
         numero_documento: prop('title_id'),
         data_emissao: compose(format('date'), prop('created_at')),

--- a/test/unit/providers/bradesco/index.js
+++ b/test/unit/providers/bradesco/index.js
@@ -18,7 +18,7 @@ test('buildPayload', async (t) => {
   t.deepEqual(payload, {
     merchant_id: '100005254',
     boleto: {
-      carteira: '25',
+      carteira: '26',
       nosso_numero: boleto.title_id,
       numero_documento: boleto.title_id,
       data_emissao: moment(boleto.created_at).format('YYYY-MM-DD'),


### PR DESCRIPTION
## Description

Change bradesco provider wallet to 26 instead of 25.

This PR can only be merged on Monday 31/07/2017.


<!--
Things to cite on the PR description: 

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel confortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
