### PR TITLE
ramda: should use 'both', not 'and'

### DIFF
--- a/src/resources/boleto/index.ts
+++ b/src/resources/boleto/index.ts
@@ -1,5 +1,5 @@
 import * as Promise from 'bluebird'
-import { and, complement, path, prop, propEq } from 'ramda'
+import { both, complement, path, prop, propEq } from 'ramda'
 import sqs from '../../lib/sqs'
 import { buildSuccessResponse, buildFailureResponse } from '../../lib/http/response'
 import { ValidationError, NotFoundError, InternalServerError } from '../../lib/errors'
@@ -50,7 +50,7 @@ export const create = (event, context, callback) => {
   // eslint-disable-next-line
   const pushBoletoToQueueConditionally = (boleto) => {
     const propNotEq = complement(propEq)
-    const shouldSendBoletoToQueue = and(
+    const shouldSendBoletoToQueue = both(
       propEq('status', 'pending_registration'),
       propNotEq('issuer', 'development')
     )


### PR DESCRIPTION
## Description

We were using 'and' in a situation that we should use 'both'.

<!--
Things to cite on the PR description: 

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel confortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
