### PR TITLE
bradesco: fix translate-response-code logs

### DIFF
--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -66,7 +66,12 @@ export const translateResponseCode = (response) => {
 
   const responseCode = response.data.status.codigo.toString()
 
-  logger.info({ status: 'succeeded', metadata: { providerResponse: response.toString() } })
+  logger.info({
+    status: 'succeeded',
+    metadata: {
+      response: response.data
+    }
+  })
 
   const defaultValue = {
     message: 'CÓDIGO INEXISTENTE',


### PR DESCRIPTION
## Description

Fix a problem with the translateResponseCode function of bradesco
provider. Previously it would print "[Object object]" on logs. Now,
it prints the full object.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
