### PR TITLE
model: fix boleto beforeValidate hook to normalize payer_address

### DIFF
--- a/test/unit/resources/boleto/model.js
+++ b/test/unit/resources/boleto/model.js
@@ -1,5 +1,9 @@
 import test from 'ava'
-import { buildModelResponse, generateBoletoCode } from '../../../../build/resources/boleto/model'
+import {
+  buildModelResponse,
+  generateBoletoCode,
+  validateModel
+} from '../../../../build/resources/boleto/model'
 
 test('buildResponse', async (t) => {
   const now = new Date()
@@ -85,4 +89,74 @@ test('generateBoletoCode', (t) => {
 
   t.is(barcode, '23792717100000020003381260000000000100097210')
   t.is(digitable_line, '23793.38128 60000.000004 01000.972107 2 71710000002000')
+})
+
+test('validateModel: with empty address', async (t) => {
+  const boleto = {
+    payer_address: {}
+  }
+
+  validateModel(boleto)
+
+  t.deepEqual(boleto.payer_address, {
+    zipcode: '04551010',
+    street: 'Rua Fidêncio Ramos',
+    street_number: '308',
+    complementary: '9º andar, conjunto 91',
+    neighborhood: 'Vila Olímpia',
+    city: 'São Paulo',
+    state: 'SP'
+  }, 'should use default address')
+})
+
+test('validateModel: with complete address', async (t) => {
+  const boleto = {
+    payer_address: {
+      zipcode: '01329010',
+      street: 'Rua dos Franceses',
+      street_number: '147',
+      complementary: 'Apt 101',
+      neighborhood: 'Morro dos Ingleses',
+      city: 'São Paulo',
+      state: 'SP'
+    }
+  }
+
+  validateModel(boleto)
+
+  t.deepEqual(boleto.payer_address, {
+    zipcode: '01329010',
+    street: 'Rua dos Franceses',
+    street_number: '147',
+    complementary: 'Apt 101',
+    neighborhood: 'Morro dos Ingleses',
+    city: 'São Paulo',
+    state: 'SP'
+  }, 'should use payer_address "as is"')
+})
+
+test('validateModel: with incomplete address', async (t) => {
+  const boleto = {
+    payer_address: {
+      zipcode: '01329010',
+      street: 'Rua dos Franceses',
+      street_number: '147',
+      complementary: 'Apt 101',
+      neighborhood: 'Morro dos Ingleses',
+      city: null,
+      state: null
+    }
+  }
+
+  validateModel(boleto)
+
+  t.deepEqual(boleto.payer_address, {
+    zipcode: '04551010',
+    street: 'Rua Fidêncio Ramos',
+    street_number: '308',
+    complementary: '9º andar, conjunto 91',
+    neighborhood: 'Vila Olímpia',
+    city: 'São Paulo',
+    state: 'SP'
+  }, 'should use default address')
 })


### PR DESCRIPTION
## Description

Previously, the model would only check if the payer_address had all the
required fields. Add a verification to check if any of the values are
null. If any value from payer_address is null, the defaultAddress should
be used.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
