### PR TITLE
travis: fix cibuild ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:9.6-alpine
     ports:
-      - 5432:5432
+      - 5432
     environment:
       - POSTGRES_PASSWORD=touchdown1!
 
@@ -12,7 +12,7 @@ services:
     image: pagarme/yopa:latest
     command: java -Xms64m -Xmx256m -jar uberjar.jar -c /tmp/yopa-in/config.yml -o /tmp/dev-env-aws-regions-override.xml
     ports:
-      - 47195:47195
+      - 47195
     volumes:
       - ./yopa-config.yml:/tmp/yopa-in/config.yml:ro
     healthcheck:


### PR DESCRIPTION
## Description

Remove port binding to host on docker-compose containers. This would
make Travis fail the builds as the 5432 port is already in use.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
