### PR TITLE
service: add timeout for register function

### DIFF
--- a/src/resources/boleto/service.ts
+++ b/src/resources/boleto/service.ts
@@ -58,7 +58,9 @@ export const register = (boleto) => {
     return Promise.resolve(boleto)
   }
 
-  return provider.register(boleto)
+  return Promise.resolve(boleto)
+    .then(provider.register)
+    .timeout(10000)
     .then(updateBoletoStatus)
     .catch(() => {
       logger.info({


### PR DESCRIPTION
## Description

Add a timeout of 10 seconds for the register function to execute. After
this send the boleto to background registering.


<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
