### PR TITLE
background-registering: process boleto on queue processor

### DIFF
--- a/src/resources/boleto/index.ts
+++ b/src/resources/boleto/index.ts
@@ -240,14 +240,7 @@ export const processBoletosToRegister = (event, context, callback) => {
 
   logger.info({ operation: 'processBoletosToRegister', status: 'started' })
 
-  const processBoleto = (item, sqsMessage) => {
-    lambda.register({
-      sqsMessage,
-      boleto_id: item.boleto_id
-    })
-  }
-
-  BoletosToRegisterQueue.startProcessing(processBoleto, {
+  BoletosToRegisterQueue.startProcessing(boletoService.processBoleto, {
     keepMessages: true
   })
 


### PR DESCRIPTION
## Description

Use the queue processor to process the sqs messages and register
boletos instead of the old way of spawning `register-boleto` lambdas for
each message at the queue.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
