### PR TITLE
logs: refactor logs to connect all actions with the same request_id

### DIFF
--- a/src/functions/database/index.ts
+++ b/src/functions/database/index.ts
@@ -34,7 +34,7 @@ export const migrate = (event, context, callback) => {
     })
 
     umzug.up()
-      .tap(() => logger.info({ status: 'succeeded' }))
+      .tap(() => logger.info({ status: 'success' }))
       .then(() => callback(null))
       .catch(err => callback(err))
       .catch((err) => {

--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -82,43 +82,6 @@ export const translateResponseCode = (response) => {
   return defaultTo(defaultValue, prop(responseCode, responseCodeMap))
 }
 
-export const verifyRegistrationStatus = (boleto) => {
-  const logger = makeLogger({ operation: 'verifyRegistrationStatus' })
-
-  return Promise.resolve(buildHeaders())
-    .then(headers => ({
-      headers,
-      url: `${endpoint}`,
-      method: 'GET',
-      params: {
-        nosso_numero: prop('title_id', boleto),
-        numero_documento: prop('title_id', boleto)
-      }
-    }))
-    .tap((request) => {
-      logger.info({
-        status: 'started',
-        metadata: {
-          request: { body: request.data }
-        }
-      })
-    })
-    .then(axios.request)
-    .then(translateResponseCode)
-    .tap((response) => {
-      logger.info({
-        status: 'succeeded',
-        metadata: { status: response.status, data: response.data }
-      })
-    })
-    .tapCatch(err => logger.error({
-      status: 'failed',
-      metadata: {
-        err: pathOr(err, ['response', 'data'], err)
-      }
-    }))
-}
-
 export const register = (boleto) => {
   const logger = makeLogger({ operation: 'register' })
 
@@ -142,13 +105,6 @@ export const register = (boleto) => {
     })
     .then(axios.request)
     .then(translateResponseCode)
-    .then((translatedResponseCode) => {
-      if (translatedResponseCode.status === 'check_status') {
-        return verifyRegistrationStatus(boleto)
-      }
-
-      return translatedResponseCode
-    })
     .tap((response) => {
       logger.info({
         status: 'succeeded',

--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -82,39 +82,50 @@ export const translateResponseCode = (response) => {
   return defaultTo(defaultValue, prop(responseCode, responseCodeMap))
 }
 
-export const register = (boleto) => {
-  const logger = makeLogger({ operation: 'register' })
-
-  return Promise.all([
-    buildHeaders(),
-    buildPayload(boleto)
-  ])
-    .spread((headers, payload) => ({
-      headers,
-      data: payload,
-      url: endpoint,
-      method: 'POST'
-    }))
-    .tap((request) => {
-      logger.info({
-        status: 'started',
-        metadata: {
-          request: { body: request.data }
-        }
-      })
-    })
-    .then(axios.request)
-    .then(translateResponseCode)
-    .tap((response) => {
-      logger.info({
-        status: 'success',
-        metadata: { status: response.status, data: response.data }
-      })
-    })
-    .tapCatch(err => logger.error({
-      status: 'failed',
-      metadata: {
-        err: pathOr(err, ['response', 'data'], err)
-      }
-    }))
+const defaultOptions = {
+  requestId: `req_${Date.now()}`
 }
+
+export const getProvider = ({ requestId } = defaultOptions) => {
+  const register = (boleto) => {
+    const logger = makeLogger({ operation: 'register' })
+
+    return Promise.all([
+      buildHeaders(),
+      buildPayload(boleto)
+    ])
+      .spread((headers, payload) => ({
+        headers,
+        data: payload,
+        url: endpoint,
+        method: 'POST'
+      }))
+      .tap((request) => {
+        logger.info({
+          status: 'started',
+          metadata: {
+            request: { body: request.data }
+          }
+        })
+      })
+      .then(axios.request)
+      .then(translateResponseCode)
+      .tap((response) => {
+        logger.info({
+          status: 'success',
+          metadata: { status: response.status, data: response.data }
+        })
+      })
+      .tapCatch(err => logger.error({
+        status: 'failed',
+        metadata: {
+          err: pathOr(err, ['response', 'data'], err)
+        }
+      }))
+  }
+
+  return {
+    register
+  }
+}
+

--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -68,7 +68,7 @@ export const translateResponseCode = (response) => {
   const responseCode = response.data.status.codigo.toString()
 
   logger.info({
-    status: 'succeeded',
+    status: 'success',
     metadata: {
       response: response.data
     }
@@ -107,7 +107,7 @@ export const register = (boleto) => {
     .then(translateResponseCode)
     .tap((response) => {
       logger.info({
-        status: 'succeeded',
+        status: 'success',
         metadata: { status: response.status, data: response.data }
       })
     })

--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -63,16 +63,7 @@ export const buildPayload = boleto =>
     .then(spec => applySpec(spec)(boleto))
 
 export const translateResponseCode = (response) => {
-  const logger = makeLogger({ operation: 'translateResponseCode' })
-
   const responseCode = response.data.status.codigo.toString()
-
-  logger.info({
-    status: 'success',
-    metadata: {
-      response: response.data
-    }
-  })
 
   const defaultValue = {
     message: 'CÓDIGO INEXISTENTE',
@@ -88,7 +79,13 @@ const defaultOptions = {
 
 export const getProvider = ({ requestId } = defaultOptions) => {
   const register = (boleto) => {
-    const logger = makeLogger({ operation: 'register' })
+    const logger = makeLogger(
+      {
+        operation: 'register_boleto_on_provider',
+        provider: 'bradesco'
+      },
+      { id: requestId }
+    )
 
     return Promise.all([
       buildHeaders(),
@@ -109,6 +106,11 @@ export const getProvider = ({ requestId } = defaultOptions) => {
         })
       })
       .then(axios.request)
+      .tap(response => logger.info({
+        metadata: {
+          response: response.data
+        }
+      }))
       .then(translateResponseCode)
       .tap((response) => {
         logger.info({

--- a/src/providers/development/index.ts
+++ b/src/providers/development/index.ts
@@ -19,7 +19,7 @@ export const register = (boleto) => {
     }))
     .tap((response) => {
       logger.info({
-        status: 'succeeded',
+        status: 'success',
         metadata: {
           status: response.status,
           data: response.data

--- a/src/providers/development/index.ts
+++ b/src/providers/development/index.ts
@@ -4,27 +4,37 @@ import { makeFromLogger } from '../../lib/logger'
 
 const makeLogger = makeFromLogger('development/index')
 
-export const register = (boleto) => {
-  const getStatusFromAmount = cond([
-    [equals(5000003), always('pending_registration')],
-    [equals(5000004), always('refused')],
-    [T, always('registered')]
-  ])
+const defaultOptions = {
+  requestId: `req_${Date.now()}`
+}
 
-  const logger = makeLogger({ operation: 'register' })
+export const getProvider = ({ requestId } = defaultOptions) => {
+  const register = (boleto) => {
+    const getStatusFromAmount = cond([
+      [equals(5000003), always('pending_registration')],
+      [equals(5000004), always('refused')],
+      [T, always('registered')]
+    ])
 
-  return Promise.resolve(boleto)
-    .then(bol => ({
-      status: getStatusFromAmount(bol.amount)
-    }))
-    .tap((response) => {
-      logger.info({
-        status: 'success',
-        metadata: {
-          status: response.status,
-          data: response.data
-        }
+    const logger = makeLogger({ operation: 'register' })
+
+    return Promise.resolve(boleto)
+      .then(bol => ({
+        status: getStatusFromAmount(bol.amount)
+      }))
+      .tap((response) => {
+        logger.info({
+          status: 'success',
+          metadata: {
+            status: response.status,
+            data: response.data
+          }
+        })
       })
-    })
-    .tapCatch(err => logger.error({ status: 'failed', metadata: { err } }))
+      .tapCatch(err => logger.error({ status: 'failed', metadata: { err } }))
+  }
+
+  return {
+    register
+  }
 }

--- a/src/resources/boleto/service.ts
+++ b/src/resources/boleto/service.ts
@@ -12,256 +12,268 @@ import { defaultCuidValue } from '../../lib/database/schema'
 
 const makeLogger = makeFromLogger('boleto/service')
 
-export const create = (data) => {
-  const logger = makeLogger({ operation: 'handle_boleto_request' }, { id: defaultCuidValue('req_')() })
+export default function boletoService ({ requestId }) {
+  const create = (data) => {
+    const logger = makeLogger({ operation: 'handle_boleto_request' }, { id: requestId })
 
-  logger.info({ status: 'started', metadata: { data } })
+    logger.info({ status: 'started', metadata: { data } })
 
-  return getModel('Boleto')
-    .then(Boleto =>
-      Promise.resolve(data)
-      .then(Boleto.create.bind(Boleto))
+    return getModel('Boleto')
+      .then(Boleto =>
+        Promise.resolve(data)
+        .then(Boleto.create.bind(Boleto))
+        .tap((boleto) => {
+          logger.info({ status: 'success', metadata: { boleto } })
+        })
+        .catch((err) => {
+          logger.error({ status: 'failed', metadata: { err } })
+          return handleDatabaseErrors(err)
+        })
+      )
+  }
+
+  const register = (boleto) => {
+    const provider = findProvider(boleto.issuer)
+    const timeoutMs = process.env.NODE_ENV === 'production' ? 6000 : 25000
+
+    const logger = makeLogger({ operation: 'register' }, { id: requestId })
+
+    const updateBoletoStatus = (response) => {
+      const status = response.status
+
+      let newBoletoStatus
+
+      if (status === 'registered') {
+        newBoletoStatus = 'registered'
+      } else if (status === 'refused') {
+        newBoletoStatus = 'refused'
+      } else {
+        newBoletoStatus = 'pending_registration'
+      }
+
+      return boleto.update({
+        status: newBoletoStatus
+      })
+    }
+
+    if (boleto.status === 'refused' || boleto.status === 'registered') {
+      return Promise.resolve(boleto)
+    }
+
+    return Promise.resolve(boleto)
+      .then(provider.register)
+      .timeout(timeoutMs)
+      .then(updateBoletoStatus)
+      .catch(() => {
+        logger.info({
+          status: 'processing',
+          message: 'Boleto register failed: will send to background registering',
+          metadata: {
+            boleto
+          }
+        })
+
+        boleto.update({
+          status: 'pending_registration'
+        })
+      })
       .tap((boleto) => {
         logger.info({ status: 'success', metadata: { boleto } })
       })
       .catch((err) => {
         logger.error({ status: 'failed', metadata: { err } })
-        return handleDatabaseErrors(err)
+        throw err
       })
-    )
-}
-
-export const register = (boleto) => {
-  const provider = findProvider(boleto.issuer)
-  const timeoutMs = process.env.NODE_ENV === 'production' ? 6000 : 25000
-
-  const logger = makeLogger({ operation: 'register' }, { id: defaultCuidValue('req_')() })
-
-  const updateBoletoStatus = (response) => {
-    const status = response.status
-
-    let newBoletoStatus
-
-    if (status === 'registered') {
-      newBoletoStatus = 'registered'
-    } else if (status === 'refused') {
-      newBoletoStatus = 'refused'
-    } else {
-      newBoletoStatus = 'pending_registration'
-    }
-
-    return boleto.update({
-      status: newBoletoStatus
-    })
   }
 
-  if (boleto.status === 'refused' || boleto.status === 'registered') {
-    return Promise.resolve(boleto)
-  }
-
-  return Promise.resolve(boleto)
-    .then(provider.register)
-    .timeout(timeoutMs)
-    .then(updateBoletoStatus)
-    .catch(() => {
-      logger.info({
-        status: 'processing',
-        message: 'Boleto register failed: will send to background registering',
-        metadata: {
-          boleto
+  const registerById = id =>
+    getModel('Boleto')
+      .then(Boleto => Boleto.findOne({
+        where: {
+          id
         }
-      })
+      }))
+      .then(register)
 
-      boleto.update({
-        status: 'pending_registration'
-      })
-    })
-    .tap((boleto) => {
-      logger.info({ status: 'success', metadata: { boleto } })
-    })
-    .catch((err) => {
-      logger.error({ status: 'failed', metadata: { err } })
-      throw err
-    })
-}
+  const update = (data) => {
+    const logger = makeLogger({ operation: 'update' }, { id: requestId })
+    logger.info({ status: 'started', metadata: { data } })
 
-export const registerById = id =>
-  getModel('Boleto')
-    .then(Boleto => Boleto.findOne({
+    const id = data.id
+    const bankResponseCode = data.bank_response_code
+    const paidAmount = data.paid_amount
+
+    const query = {
       where: {
         id
       }
-    }))
-    .then(register)
-
-export const update = (data) => {
-  const logger = makeLogger({ operation: 'update' }, { id: defaultCuidValue('req_')() })
-  logger.info({ status: 'started', metadata: { data } })
-
-  const id = data.id
-  const bankResponseCode = data.bank_response_code
-  const paidAmount = data.paid_amount
-
-  const query = {
-    where: {
-      id
     }
-  }
 
-  return getModel('Boleto')
-    .then(Boleto => Boleto.findOne(query)
-      .then((boleto) => {
-        if (!boleto) {
-          throw new NotFoundError({
-            message: 'Boleto not found'
-          })
-        }
+    return getModel('Boleto')
+      .then(Boleto => Boleto.findOne(query)
+        .then((boleto) => {
+          if (!boleto) {
+            throw new NotFoundError({
+              message: 'Boleto not found'
+            })
+          }
 
-        return boleto.update({
-          paid_amount: paidAmount || boleto.paid_amount,
-          bank_response_code: bankResponseCode || boleto.bank_response_code
-        })
-      })
-      .tap((boleto) => {
-        logger.info({ status: 'success', metadata: { boleto } })
-      })
-      .catch(handleDatabaseErrors))
-}
-
-export const index = ({ page, count, token, title_id }) => {
-  const whereQuery = {
-    where: {
-    }
-  }
-
-  const orderQuery = {
-    order: 'id DESC'
-  }
-
-  const possibleFields = { token, title_id }
-
-  for (const field in possibleFields) {
-    if (possibleFields[field]) {
-      whereQuery.where[field] = possibleFields[field]
-    }
-  }
-
-  const paginationQuery = getPaginationQuery({ page, count })
-
-  const query = mergeAll([
-    {},
-    paginationQuery,
-    whereQuery,
-    orderQuery
-  ])
-
-  return getModel('Boleto')
-    .then(Boleto => Boleto.findAll(query)
-      .catch(handleDatabaseErrors))
-}
-
-export const show = (id) => {
-  const query = {
-    where: {
-      id
-    }
-  }
-
-  return getModel('Boleto')
-    .then(Boleto => Boleto.findOne(query)
-      .then((boleto) => {
-        if (!boleto) {
-          throw new NotFoundError({
-            message: 'Boleto not found'
-          })
-        }
-
-        return boleto
-      })
-      .catch(handleDatabaseErrors))
-}
-
-export const processBoleto = (item, sqsMessage) => {
-  const { boleto_id } = item
-
-  const logger = makeLogger({ operation: 'process_boleto' }, { id: defaultCuidValue('req_')() })
-
-  // eslint-disable-next-line
-  const removeBoletoFromQueueConditionally = (boleto) => {
-    if (boleto.status === 'registered' || boleto.status === 'refused') {
-      logger.info({
-        sub_operation: 'remove_from_background_queue',
-        status: 'started',
-        metadata: { boleto_id: boleto.id }
-      })
-      return BoletosToRegisterQueue.remove(sqsMessage)
-        .then(() => {
-          logger.info({
-            sub_operation: 'remove_from_background_queue',
-            status: 'success',
-            metadata: { boleto_id: boleto.id }
+          return boleto.update({
+            paid_amount: paidAmount || boleto.paid_amount,
+            bank_response_code: bankResponseCode || boleto.bank_response_code
           })
         })
-        .catch((err) => {
-          logger.info({
-            sub_operation: 'remove_from_background_queue',
-            status: 'failed',
-            metadata: { err, boleto_id: boleto.id }
-          })
-          throw err
+        .tap((boleto) => {
+          logger.info({ status: 'success', metadata: { boleto } })
         })
-    }
+        .catch(handleDatabaseErrors))
   }
 
-  const sendMessageToUserQueueConditionally = (boleto) => {
-    if (boleto.status === 'registered' || boleto.status === 'refused') {
-      logger.info({
-        sub_operation: 'send_message_to_client_queue',
-        status: 'started',
-        metadata: { boleto_id: boleto.id }
-      })
-
-      const params = {
-        MessageBody: JSON.stringify({
-          boleto_id: boleto.id,
-          status: boleto.status,
-          reference_id: boleto.reference_id
-        }),
-        QueueUrl: boleto.queue_url
+  const index = ({ page, count, token, title_id }) => {
+    const whereQuery = {
+      where: {
       }
-
-      return sqs.sendMessage(params).promise()
-        .then(() => {
-          logger.info({
-            sub_operation: 'send_message_to_client_queue',
-            status: 'success',
-            metadata: { boleto_id: boleto.id }
-          })
-        })
-        .catch((err) => {
-          logger.info({
-            sub_operation: 'send_message_to_client_queue',
-            status: 'failed',
-            metadata: { err, boleto_id: boleto.id }
-          })
-          throw err
-        })
     }
+
+    const orderQuery = {
+      order: 'id DESC'
+    }
+
+    const possibleFields = { token, title_id }
+
+    for (const field in possibleFields) {
+      if (possibleFields[field]) {
+        whereQuery.where[field] = possibleFields[field]
+      }
+    }
+
+    const paginationQuery = getPaginationQuery({ page, count })
+
+    const query = mergeAll([
+      {},
+      paginationQuery,
+      whereQuery,
+      orderQuery
+    ])
+
+    return getModel('Boleto')
+      .then(Boleto => Boleto.findAll(query)
+        .catch(handleDatabaseErrors))
   }
 
-  logger.info({ status: 'started', metadata: { item } })
+  const show = (id) => {
+    const query = {
+      where: {
+        id
+      }
+    }
 
-  return Promise.resolve(boleto_id)
-    .then(registerById)
-    .tap(removeBoletoFromQueueConditionally)
-    .tap(sendMessageToUserQueueConditionally)
-    .tap((response) => {
-      logger.info({
-        status: 'success',
-        metadata: { body: response.body, statusCode: response.statusCode }
+    return getModel('Boleto')
+      .then(Boleto => Boleto.findOne(query)
+        .then((boleto) => {
+          if (!boleto) {
+            throw new NotFoundError({
+              message: 'Boleto not found'
+            })
+          }
+
+          return boleto
+        })
+        .catch(handleDatabaseErrors))
+  }
+
+  const processBoleto = (item, sqsMessage) => {
+    const { boleto_id } = item
+
+    const logger = makeLogger({ operation: 'process_boleto' }, { id: requestId })
+
+    // eslint-disable-next-line
+    const removeBoletoFromQueueConditionally = (boleto) => {
+      if (boleto.status === 'registered' || boleto.status === 'refused') {
+        logger.info({
+          sub_operation: 'remove_from_background_queue',
+          status: 'started',
+          metadata: { boleto_id: boleto.id }
+        })
+        return BoletosToRegisterQueue.remove(sqsMessage)
+          .then(() => {
+            logger.info({
+              sub_operation: 'remove_from_background_queue',
+              status: 'success',
+              metadata: { boleto_id: boleto.id }
+            })
+          })
+          .catch((err) => {
+            logger.info({
+              sub_operation: 'remove_from_background_queue',
+              status: 'failed',
+              metadata: { err, boleto_id: boleto.id }
+            })
+            throw err
+          })
+      }
+    }
+
+    const sendMessageToUserQueueConditionally = (boleto) => {
+      if (boleto.status === 'registered' || boleto.status === 'refused') {
+        logger.info({
+          sub_operation: 'send_message_to_client_queue',
+          status: 'started',
+          metadata: { boleto_id: boleto.id }
+        })
+
+        const params = {
+          MessageBody: JSON.stringify({
+            boleto_id: boleto.id,
+            status: boleto.status,
+            reference_id: boleto.reference_id
+          }),
+          QueueUrl: boleto.queue_url
+        }
+
+        return sqs.sendMessage(params).promise()
+          .then(() => {
+            logger.info({
+              sub_operation: 'send_message_to_client_queue',
+              status: 'success',
+              metadata: { boleto_id: boleto.id }
+            })
+          })
+          .catch((err) => {
+            logger.info({
+              sub_operation: 'send_message_to_client_queue',
+              status: 'failed',
+              metadata: { err, boleto_id: boleto.id }
+            })
+            throw err
+          })
+      }
+    }
+
+    logger.info({ status: 'started', metadata: { item } })
+
+    return Promise.resolve(boleto_id)
+      .then(registerById)
+      .tap(removeBoletoFromQueueConditionally)
+      .tap(sendMessageToUserQueueConditionally)
+      .tap((response) => {
+        logger.info({
+          status: 'success',
+          metadata: { body: response.body, statusCode: response.statusCode }
+        })
       })
-    })
-    .catch((err) => {
-      logger.error({ status: 'failed', metadata: { err } })
-    })
+      .catch((err) => {
+        logger.error({ status: 'failed', metadata: { err } })
+      })
+  }
+
+  return {
+    create,
+    register,
+    registerById,
+    update,
+    index,
+    show,
+    processBoleto
+  }
 }

--- a/src/resources/boleto/service.ts
+++ b/src/resources/boleto/service.ts
@@ -33,7 +33,8 @@ export default function boletoService ({ requestId }) {
   }
 
   const register = (boleto) => {
-    const provider = findProvider(boleto.issuer)
+    const Provider = findProvider(boleto.issuer)
+    const provider = Provider.getProvider({ requestId })
     const timeoutMs = process.env.NODE_ENV === 'production' ? 6000 : 25000
 
     const logger = makeLogger({ operation: 'register' }, { id: requestId })
@@ -64,12 +65,13 @@ export default function boletoService ({ requestId }) {
       .then(provider.register)
       .timeout(timeoutMs)
       .then(updateBoletoStatus)
-      .catch(() => {
+      .catch((err) => {
         logger.info({
           status: 'processing',
           message: 'Boleto register failed: will send to background registering',
           metadata: {
-            boleto
+            boleto,
+            err
           }
         })
 

--- a/test/functional/boleto/create/bradesco/pending.js
+++ b/test/functional/boleto/create/bradesco/pending.js
@@ -4,19 +4,24 @@ import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock, mockFunction, restoreFunction } from '../../../../helpers/boleto'
 import * as boletoHandler from '../../../../../build/resources/boleto'
-import * as provider from '../../../../../build/providers/bradesco'
+import * as Provider from '../../../../../build/providers/bradesco'
 import { findItemOnQueue, purgeQueue } from '../../../../helpers/sqs'
 import { BoletosToRegisterQueue } from '../../../../../build/resources/boleto/queues'
 
 const create = normalizeHandler(boletoHandler.create)
 
 test.before(async () => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'unknown' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'unknown' })
+    }
+  }))
+
   await purgeQueue(BoletosToRegisterQueue)
 })
 
 test.after(() => {
-  restoreFunction(provider, 'register')
+  restoreFunction(Provider, 'getProvider')
 })
 
 test('creates a boleto (provider unknown)', async (t) => {

--- a/test/functional/boleto/create/bradesco/refused.js
+++ b/test/functional/boleto/create/bradesco/refused.js
@@ -4,16 +4,20 @@ import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock, mockFunction, restoreFunction } from '../../../../helpers/boleto'
 import * as boletoHandler from '../../../../../build/resources/boleto'
-import * as provider from '../../../../../build/providers/bradesco'
+import * as Provider from '../../../../../build/providers/bradesco'
 
 const create = normalizeHandler(boletoHandler.create)
 
 test.before(() => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'refused' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'refused' })
+    }
+  }))
 })
 
 test.after(async () => {
-  restoreFunction(provider, 'register')
+  restoreFunction(Provider, 'getProvider')
 })
 
 test('creates a boleto (provider refused)', async (t) => {

--- a/test/functional/boleto/processBoletosToRegister/registered.js
+++ b/test/functional/boleto/processBoletosToRegister/registered.js
@@ -4,7 +4,7 @@ import { assert } from '../../../helpers/chai'
 import { normalizeHandler } from '../../../helpers/normalizer'
 import * as boletoHandler from '../../../../build/resources/boleto'
 import { mock, userQueue, mockFunction, restoreFunction } from '../../../helpers/boleto'
-import * as provider from '../../../../build/providers/bradesco'
+import * as Provider from '../../../../build/providers/bradesco'
 import { findItemOnQueue, purgeQueue } from '../../../helpers/sqs'
 import lambda from '../../../../build/resources/boleto/lambda'
 import { BoletosToRegisterQueue } from '../../../../build/resources/boleto/queues'
@@ -14,7 +14,11 @@ const create = normalizeHandler(boletoHandler.create)
 const processBoletosToRegister = promisify(boletoHandler.processBoletosToRegister)
 
 test.before(async () => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'unknown' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'unknown' })
+    }
+  }))
 
   await purgeQueue(BoletosToRegisterQueue)
   await purgeQueue(userQueue)
@@ -34,12 +38,16 @@ test.before(async () => {
 })
 
 test.after(async () => {
-  restoreFunction(provider, 'register')
+  restoreFunction(Provider, 'getProvider')
   restoreFunction(lambda, 'register')
 })
 
 test('process many boletos (provider registered)', async (t) => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'registered' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'registered' })
+    }
+  }))
 
   await processBoletosToRegister({}, {})
 

--- a/test/functional/boleto/register/pending.js
+++ b/test/functional/boleto/register/pending.js
@@ -3,14 +3,18 @@ import { Promise, promisify } from 'bluebird'
 import { mock, mockFunction, restoreFunction } from '../../../helpers/boleto'
 import { normalizeHandler } from '../../../helpers/normalizer'
 import * as boletoHandler from '../../../../build/resources/boleto'
-import * as provider from '../../../../build/providers/bradesco'
+import * as Provider from '../../../../build/providers/bradesco'
 
 test.before(async () => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'unknown' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'unknown' })
+    }
+  }))
 })
 
 test.after(() => {
-  restoreFunction(provider, 'register')
+  restoreFunction(Provider, 'getProvider')
 })
 
 const create = normalizeHandler(boletoHandler.create)

--- a/test/functional/boleto/register/refused.js
+++ b/test/functional/boleto/register/refused.js
@@ -3,20 +3,24 @@ import { Promise, promisify } from 'bluebird'
 import { mock, mockFunction, restoreFunction, userQueueUrl, userQueue } from '../../../helpers/boleto'
 import { normalizeHandler } from '../../../helpers/normalizer'
 import * as boletoHandler from '../../../../build/resources/boleto'
-import * as provider from '../../../../build/providers/bradesco'
+import * as Provider from '../../../../build/providers/bradesco'
 import { findItemOnQueue, purgeQueue } from '../../../helpers/sqs'
 
 const create = normalizeHandler(boletoHandler.create)
-
 const register = promisify(boletoHandler.register)
 
 test.before(() => {
-  mockFunction(provider, 'register', () => Promise.resolve({ status: 'refused' }))
+  mockFunction(Provider, 'getProvider', () => ({
+    register () {
+      return Promise.resolve({ status: 'refused' })
+    }
+  }))
+
   purgeQueue(userQueue)
 })
 
 test.after(() => {
-  restoreFunction(provider, 'register')
+  restoreFunction(Provider, 'getProvider')
 })
 
 test('registers a boleto (provider refused)', async (t) => {

--- a/test/helpers/normalizer.js
+++ b/test/helpers/normalizer.js
@@ -5,6 +5,9 @@ const parseHandlerEvent = event => Object.assign({}, event, {
 })
 
 const computeHandlerEvent = event => Object.assign({}, event, {
+  headers: {
+    'x-request-id': 'req_a872b1c123'
+  },
   body: JSON.stringify(event.body)
 })
 

--- a/test/integration/providers/bradesco/index.js
+++ b/test/integration/providers/bradesco/index.js
@@ -1,22 +1,11 @@
 import test from 'ava'
 import { createBoleto } from '../../../helpers/boleto'
-import { register, verifyRegistrationStatus } from '../../../../build/providers/bradesco'
+import { register } from '../../../../build/providers/bradesco'
 
 test('register', async (t) => {
   const boleto = await createBoleto()
 
   const response = await register(boleto)
-
-  t.is(response.status, 'registered')
-})
-
-test('verifyRegistrationStatus', async (t) => {
-  const boleto = await createBoleto()
-  boleto.issuer_id = boleto.title_id
-
-  await register(boleto)
-
-  const response = await verifyRegistrationStatus(boleto)
 
   t.is(response.status, 'registered')
 })

--- a/test/integration/providers/bradesco/index.js
+++ b/test/integration/providers/bradesco/index.js
@@ -1,6 +1,8 @@
 import test from 'ava'
 import { createBoleto } from '../../../helpers/boleto'
-import { register } from '../../../../build/providers/bradesco'
+import * as Provider from '../../../../build/providers/bradesco'
+
+const { register } = Provider.getProvider()
 
 test('register', async (t) => {
   const boleto = await createBoleto()


### PR DESCRIPTION
## Description

Connect all actions with the same requestId on logs. We now accept a `x-request-id` header on `/POST /boletos` that we're going to use to keep track of a given request.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
