### PR TITLE
bradesco: use now() as bradesco's data_emissao parameter

### DIFF
--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import * as moment from 'moment'
 import * as Promise from 'bluebird'
 import {
   always,
@@ -41,7 +42,7 @@ export const buildPayload = boleto =>
         carteira: always('26'),
         nosso_numero: prop('title_id'),
         numero_documento: prop('title_id'),
-        data_emissao: compose(format('date'), prop('created_at')),
+        data_emissao: compose(format('date'), always(moment().toDate())),
         data_vencimento: compose(format('date'), prop('expiration_date')),
         valor_titulo: prop('amount'),
         pagador: {

--- a/test/unit/providers/bradesco/index.js
+++ b/test/unit/providers/bradesco/index.js
@@ -21,7 +21,7 @@ test('buildPayload', async (t) => {
       carteira: '26',
       nosso_numero: boleto.title_id,
       numero_documento: boleto.title_id,
-      data_emissao: moment(boleto.created_at).format('YYYY-MM-DD'),
+      data_emissao: moment().format('YYYY-MM-DD'),
       data_vencimento: moment(boleto.expiration_date).format('YYYY-MM-DD'),
       valor_titulo: 2000,
       pagador: {


### PR DESCRIPTION
## Description

We are now using the current moment as Bradesco's `data_emissao` parameter instead of boleto's created_at property. We're doing this to avoid errors with boletos that are created at one day and sent to register in another day. E.g. a boleto created at `23:59:59` on day 1 will be sent to register on `00:00:00` on day 2. Because bradesco only consider the date in a `YYYY-MM-DD` format, this would fail.

closes https://github.com/pagarme/ghostbusters/issues/85

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
