### PR TITLE
boleto: add 'issuer-response-code' field

### DIFF
--- a/src/database/migrations/20171107000001-add-issuer-response-code-to-boleto.js
+++ b/src/database/migrations/20171107000001-add-issuer-response-code-to-boleto.js
@@ -1,0 +1,12 @@
+import { STRING } from 'sequelize'
+
+export default {
+  up: (queryInterface, Sequelize) =>
+    queryInterface.addColumn('Boletos', 'issuer_response_code', {
+      type: STRING
+    }
+  ),
+
+  down: (queryInterface, Sequelize) =>
+    queryInterface.removeColumn('Boletos', 'issuer_response_code')
+}

--- a/src/providers/bradesco/index.ts
+++ b/src/providers/bradesco/index.ts
@@ -4,6 +4,7 @@ import * as Promise from 'bluebird'
 import {
   always,
   applySpec,
+  assoc,
   compose,
   defaultTo,
   path,
@@ -71,7 +72,11 @@ export const translateResponseCode = (response) => {
     status: 'unknown'
   }
 
-  return defaultTo(defaultValue, prop(responseCode, responseCodeMap))
+  return assoc(
+    'issuer_response_code',
+    responseCode,
+    defaultTo(defaultValue, prop(responseCode, responseCodeMap))
+  )
 }
 
 const defaultOptions = {

--- a/src/resources/boleto/model.ts
+++ b/src/resources/boleto/model.ts
@@ -63,6 +63,7 @@ export const buildModelResponse = responseObjectBuilder(boleto =>
       'issuer_agency',
       'issuer_wallet',
       'issuer_id',
+      'issuer_response_code',
       'title_id',
       'barcode',
       'digitable_line',
@@ -259,6 +260,10 @@ function create (database) {
     },
 
     bank_response_code: {
+      type: STRING
+    },
+
+    issuer_response_code: {
       type: STRING
     }
   // tslint:disable-next-line:align

--- a/src/resources/boleto/service.ts
+++ b/src/resources/boleto/service.ts
@@ -46,9 +46,7 @@ export default function boletoService ({ requestId }) {
 
     const logger = makeLogger({ operation: 'register' }, { id: requestId })
 
-    const updateBoletoStatus = (response) => {
-      const status = response.status
-
+    const updateBoletoStatus = ({ issuer_response_code, status }) => {
       let newBoletoStatus
 
       if (status === 'registered') {
@@ -60,6 +58,7 @@ export default function boletoService ({ requestId }) {
       }
 
       return boleto.update({
+        issuer_response_code,
         status: newBoletoStatus
       })
     }

--- a/test/functional/boleto/create/bradesco/pending.js
+++ b/test/functional/boleto/create/bradesco/pending.js
@@ -13,7 +13,10 @@ const create = normalizeHandler(boletoHandler.create)
 test.before(async () => {
   mockFunction(Provider, 'getProvider', () => ({
     register () {
-      return Promise.resolve({ status: 'unknown' })
+      return Promise.resolve({
+        status: 'unknown',
+        issuer_response_code: 'unknown'
+      })
     }
   }))
 
@@ -46,6 +49,7 @@ test('creates a boleto (provider unknown)', async (t) => {
 
   assert.containSubset(body, {
     status: 'pending_registration',
+    issuer_response_code: 'unknown',
     paid_amount: 0,
     amount: payload.amount,
     instructions: payload.instructions,

--- a/test/functional/boleto/create/bradesco/refused.js
+++ b/test/functional/boleto/create/bradesco/refused.js
@@ -11,7 +11,10 @@ const create = normalizeHandler(boletoHandler.create)
 test.before(() => {
   mockFunction(Provider, 'getProvider', () => ({
     register () {
-      return Promise.resolve({ status: 'refused' })
+      return Promise.resolve({
+        status: 'refused',
+        issuer_response_code: '930056'
+      })
     }
   }))
 })
@@ -36,6 +39,7 @@ test('creates a boleto (provider refused)', async (t) => {
 
   assert.containSubset(body, {
     status: 'refused',
+    issuer_response_code: '930056',
     paid_amount: 0,
     amount: payload.amount,
     instructions: payload.instructions,

--- a/test/functional/boleto/create/bradesco/registered.js
+++ b/test/functional/boleto/create/bradesco/registered.js
@@ -19,7 +19,9 @@ test('creates a boleto (provider success)', async (t) => {
 
   t.true(body.title_id != null)
   t.true(body.barcode != null)
+  t.true(body.issuer_response_code != null)
   t.true(typeof body.title_id === 'number')
+  t.true(typeof body.issuer_response_code === 'string')
 
   assert.containSubset(body, {
     status: 'registered',


### PR DESCRIPTION
## Description

Since Bradesco send us a response with a code when trying to register a
boleto, we'll save this code in the model to query boletos by
issuer-response-code.

Closes https://github.com/pagarme/ghostbusters/issues/5

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

  