### PR TITLE
chore: bump nyc version to remove warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "eslint": "4.14.0",
     "eslint-config-pagarme-base": "2.0.0",
     "eslint-plugin-import": "2.7.0",
-    "nyc": "10.3.2"
+    "nyc": "11.4.1"
   }
 }


### PR DESCRIPTION
## Description

Update `nyc` package version to stop printing this
`(node:58) Warning: process.on(SIGPROF) is reserved while debugging`
to the console when running tests.
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
