### PR TITLE
web-server: add graceful shutdown

### DIFF
--- a/src/bin/server.js
+++ b/src/bin/server.js
@@ -1,34 +1,11 @@
-const express = require('express')
-const bodyParser = require('body-parser')
-
-const { authentication } = require('../middlewares/authentication')
-const {
-  create,
-  index,
-  show,
-  update,
-  defaultHandler,
-} = require('../resources/boleto')
-const { defaultResourceHandler } = require('../resources')
-
-const app = express()
-
 const { PORT = 3000 } = process.env
 
-app.use(bodyParser.json())
+const app = require('../server')
+const { setupGracefulShutdown } = require('../server/shutdown')
 
-app.get('/', (req, res) => res.json({ ok: 'ok' }))
-
-app.use('/boletos', authentication)
-app.post('/boletos', create)
-app.get('/boletos', index)
-app.get('/boletos/:id', show)
-app.patch('/boletos/:id', update)
-app.all('/boletos', defaultHandler)
-
-app.all('*', defaultResourceHandler)
-
-app.listen(
+const server = app.listen(
   PORT,
   () => console.log(`Superbowleto listening on port: ${PORT}`)
 )
+
+setupGracefulShutdown(process, server)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,30 @@
+const express = require('express')
+const bodyParser = require('body-parser')
+
+const { authentication } = require('../middlewares/authentication')
+const {
+  create,
+  index,
+  show,
+  update,
+  defaultHandler,
+} = require('../resources/boleto')
+const { defaultResourceHandler } = require('../resources')
+
+const app = express()
+
+
+app.use(bodyParser.json())
+
+app.get('/', (req, res) => res.json({ ok: 'ok' }))
+
+app.use('/boletos', authentication)
+app.post('/boletos', create)
+app.get('/boletos', index)
+app.get('/boletos/:id', show)
+app.patch('/boletos/:id', update)
+app.all('/boletos', defaultHandler)
+
+app.all('*', defaultResourceHandler)
+
+module.exports = app

--- a/src/server/shutdown.js
+++ b/src/server/shutdown.js
@@ -1,0 +1,23 @@
+const { forEachObjIndexed } = require('ramda')
+
+const shutdown = (process, server, value) => () =>
+  server.close(() => process.exit(128 + value))
+
+const shutdownEvent = (process, server) => (value, signal) =>
+  process.on(signal, shutdown(process, server, value))
+
+const setupGracefulShutdown = (process, server) => {
+  const signals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGTERM: 15,
+  }
+
+  forEachObjIndexed(shutdownEvent(process, server), signals)
+}
+
+module.exports = {
+  setupGracefulShutdown,
+  shutdown,
+  shutdownEvent,
+}

--- a/test/unit/server/shutdown.js
+++ b/test/unit/server/shutdown.js
@@ -1,0 +1,74 @@
+import test from 'ava'
+import sinon from 'sinon'
+import { is } from 'ramda'
+import {
+  shutdown,
+  shutdownEvent,
+  setupGracefulShutdown,
+} from '../../../src/server/shutdown'
+
+test('should shutdown the process after the server is closed', (t) => {
+  const mockProcess = {
+    exit: sinon.spy(),
+  }
+
+  const mockServer = {
+    close: sinon.spy(),
+  }
+
+  const mockValue = 15
+
+  shutdown(mockProcess, mockServer, mockValue)()
+
+  const closeCallback = mockServer.close.args[0][0]
+  closeCallback()
+
+  t.is(mockServer.close.callCount, 1)
+  t.is(mockProcess.exit.callCount, 1)
+  t.is(mockProcess.exit.args[0][0], 128 + mockValue)
+})
+
+test('should add event to process', (t) => {
+  const mockProcess = {
+    on: sinon.spy(),
+  }
+
+  const mockServer = {}
+
+  const mockValue = 15
+
+  const mockSignal = 'SIGTERM'
+
+  shutdownEvent(mockProcess, mockServer)(mockValue, mockSignal)
+
+  const [signalArg, callbackArg] = mockProcess.on.args[0]
+
+  t.is(mockProcess.on.callCount, 1)
+  t.true(is(Function, callbackArg))
+  t.is(signalArg, mockSignal)
+})
+
+test('should add events for all shutdown signals of the process', (t) => {
+  const mockSignals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGTERM: 15,
+  }
+
+  const mockProcess = {
+    on: sinon.spy(),
+  }
+
+  const mockServer = {}
+
+  setupGracefulShutdown(mockProcess, mockServer)
+
+  const [SIGHUP] = mockProcess.on.args[0]
+  const [SIGINT] = mockProcess.on.args[1]
+  const [SIGTERM] = mockProcess.on.args[2]
+
+  t.is(mockProcess.on.callCount, 3)
+  t.true(SIGHUP in mockSignals)
+  t.true(SIGINT in mockSignals)
+  t.true(SIGTERM in mockSignals)
+})


### PR DESCRIPTION
## Description

Every time the server receives from the OS one of these
signals (SIGHUP, SIGINT, SIGTERM) it will stop receiving
requests and it will finish to serve all requests that were being
processes at the moment. After all that, the process will stop as
the OS requested.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

this closes https://github.com/pagarme/ghostbusters/issues/33