### PR TITLE
web-server: add robots.txt route

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,6 +19,7 @@ const allRoutesExceptHealthCheck = /^\/(?!_health_check(\/|$)).*$/i
 app.use(bodyParser.json())
 
 app.disable('x-powered-by')
+app.get('/robots.txt', (req, res) => res.send(200, 'User-Agent: *\nDisallow: /'))
 app.get('/_health_check', (req, res) => res.send(200))
 app.use(allRoutesExceptHealthCheck, redirectHttp)
 app.use('/boletos', authentication)


### PR DESCRIPTION
## Description

This PR implements the `/robots.txt` route, that always returns `User-Agent: * Disallow: /`. This is needed so Google and other search engines don't crawl our boletos and routes.

Closes pagarme/ghostbusters#170

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
