### PR TITLE
bradesco: fix usage of operationId

### DIFF
--- a/src/providers/bradesco/index.js
+++ b/src/providers/bradesco/index.js
@@ -78,17 +78,17 @@ const translateResponseCode = (response) => {
 }
 
 const defaultOptions = {
-  requestId: `req_${Date.now()}`,
+  operationId: `req_${Date.now()}`,
 }
 
-const getProvider = ({ requestId } = defaultOptions) => {
+const getProvider = ({ operationId } = defaultOptions) => {
   const register = (boleto) => {
     const logger = makeLogger(
       {
         operation: 'register_boleto_on_provider',
         provider: 'bradesco',
       },
-      { id: requestId }
+      { id: operationId }
     )
 
     const headers = buildHeaders()


### PR DESCRIPTION
## Description
Before the term used was requestId, but now it is
operationId, this should've been changed before so
it is a fix.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

this closes https://github.com/pagarme/ghostbusters/issues/171