### PR TITLE
docker: make migration a service on docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ start-db:
 .PHONY: start-db
 
 migrate:
-	@docker-compose run superbowleto-web ./script/setup
+	@docker-compose run migrate
 .PHONY: migrate
 
 setup-db: start-db migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,19 @@ services:
     depends_on:
       - test-dependencies
 
+  migrate:
+    build: .
+    entrypoint: ./script/setup
+    environment:
+      - API_ENV=test
+    volumes:
+      - .:/superbowleto
+      - /superbowleto/node_modules
+    depends_on:
+      - postgres
+    links:
+      - postgres
+
   superbowleto-web:
     build: .
     entrypoint: node src/bin/server.js


### PR DESCRIPTION
## Description

This PR basically removes the responsability of the `Makefile` to choose which script to run and it delegates to a new service on the `docker-compose.yml` file.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
