### PR TITLE
bradesco: fix intermittent test date

### DIFF
--- a/test/unit/providers/bradesco/index.js
+++ b/test/unit/providers/bradesco/index.js
@@ -21,8 +21,8 @@ test('buildPayload', async (t) => {
       carteira: '26',
       nosso_numero: boleto.title_id,
       numero_documento: boleto.title_id,
-      data_emissao: moment().format('YYYY-MM-DD'),
-      data_vencimento: moment(boleto.expiration_date).format('YYYY-MM-DD'),
+      data_emissao: moment().tz('America/Sao_Paulo').format('YYYY-MM-DD'),
+      data_vencimento: moment(boleto.expiration_date).tz('America/Sao_Paulo').format('YYYY-MM-DD'),
       valor_titulo: 2000,
       pagador: {
         nome: 'David Bowie',


### PR DESCRIPTION
## Description

The `buildPayload` unit test of the `bradesco` provider
had a problem, some times the test failed and others it
didn't. The issue was that the dates used on the comparison
were not using the `moment-timezone` library, so if the test
ran late on a day, it would think it is the next day and
the `buildPayload` function which uses `moment-timezone`
would get the correct date on the correct timezone. This
commit fixes this issue by adding the timezone to the test.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
