### PR TITLE
service: cover bradesco down time on register

### DIFF
--- a/src/providers/bradesco/temp.js
+++ b/src/providers/bradesco/temp.js
@@ -1,0 +1,14 @@
+const moment = require('moment-timezone')
+
+const SP_TZ = 'America/Sao_Paulo'
+
+const isBradescoOff = () => {
+  const now = moment().tz(SP_TZ)
+  const bradescoStartTime = moment('2018-08-26 23:00:00').tz(SP_TZ)
+  const bradescoEndTime = moment('2018-08-27 05:01:00').tz(SP_TZ)
+  return now.isBetween(bradescoStartTime, bradescoEndTime)
+}
+
+module.exports = {
+  isBradescoOff,
+}

--- a/test/unit/providers/bradesco/temp.js
+++ b/test/unit/providers/bradesco/temp.js
@@ -1,0 +1,22 @@
+import test from 'ava'
+import sinon from 'sinon'
+import moment from 'moment'
+import { isBradescoOff } from '../../../../src/providers/bradesco/temp'
+
+test('isBradescoOff when Bradesco is online', (t) => {
+  const time = moment('2018-08-26 22:59:59').valueOf()
+  const timer = sinon.useFakeTimers(time)
+
+  t.is(isBradescoOff(), false)
+
+  timer.restore()
+})
+
+test('isBradescoOff when Bradesco is offline', (t) => {
+  const time = moment('2018-08-27 05:00:00').valueOf()
+  const timer = sinon.useFakeTimers(time)
+
+  t.is(isBradescoOff(), true)
+
+  timer.restore()
+})


### PR DESCRIPTION
## Description

The Bradesco provider will be offline on a specific
date. Add fake register logic to cover this period so
that all boletos sent will be registered later.

Co-authored-by: thor99 <thor.garcia@pagar.me>
Co-authored-by: lucianopf <luciano.franca@pagar.me>

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

This closes https://github.com/pagarme/ghostbusters/issues/297