### PR TITLE
chore: bump node-boleto

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment": "https://github.com/pagarme/moment/archive/0.0.2.tar.gz",
     "moment-timezone": "0.5.21",
     "newrelic": "4.11.0",
-    "node-boleto": "2.0.2",
+    "node-boleto": "2.0.6",
     "nodecredstash": "1.1.0",
     "pg": "7.7.1",
     "ramda": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment": "https://github.com/pagarme/moment/archive/0.0.2.tar.gz",
     "moment-timezone": "0.5.21",
     "newrelic": "4.11.0",
-    "node-boleto": "2.0.6",
+    "node-boleto": "2.1.0",
     "nodecredstash": "1.1.0",
     "pg": "7.7.1",
     "ramda": "0.23.0",


### PR DESCRIPTION
## Description
This PR aims to bump the version of the `node-boleto` dependency, and by so avoiding having headaches with different timezones based at input hours, since we only matter for days.