### PR TITLE
Wallet: Setup issuer_wallet

### DIFF
--- a/src/providers/bradesco/index.js
+++ b/src/providers/bradesco/index.js
@@ -15,6 +15,7 @@ const {
   length,
   multiply,
   path,
+  pathOr,
   pipe,
   prop,
   propSatisfies,
@@ -73,7 +74,7 @@ const buildPayload = (boleto) => {
   const spec = applySpec({
     merchant_id: always(merchantId),
     boleto: {
-      carteira: always('26'),
+      carteira: pathOr('26', ['issuer_wallet']),
       nosso_numero: prop('title_id'),
       numero_documento: prop('title_id'),
       data_emissao: compose(format('date'), always(moment().toDate())),

--- a/test/unit/providers/bradesco/index.js
+++ b/test/unit/providers/bradesco/index.js
@@ -124,6 +124,26 @@ test('buildPayload with a cnpj number on company_document_number', async (t) => 
   })
 })
 
+test('buildPayload without a issuer_wallet', async (t) => {
+  const boleto = await createBoleto({
+    issuer_wallet: undefined,
+  })
+
+  const payload = buildPayload(boleto)
+
+  t.is(payload.boleto.carteira, '26')
+})
+
+test('buildPayload with issuer_wallet of 25', async (t) => {
+  const boleto = await createBoleto({
+    issuer_wallet: '25',
+  })
+
+  const payload = buildPayload(boleto)
+
+  t.is(payload.boleto.carteira, '25')
+})
+
 test('translateResponseCode: with a "registered" code', (t) => {
   const response = translateResponseCode({
     data: {


### PR DESCRIPTION
# Description

This PR aims to allow us to define the desired issuer_wallet when its manually provided.

PS: I would love to use `propOr` since we're talking about a single prop instead of `pathOr`, but it seems that there's a bug at Ramda at the current version we're using at Superbowleto.

Here are 2 screenshots either with the newest version and with the current version

![propOr_2](https://user-images.githubusercontent.com/8251208/65085161-c032ab00-d983-11e9-87ab-92299710dde7.png)
![propOr_1](https://user-images.githubusercontent.com/8251208/65085172-c45ec880-d983-11e9-9350-669c3e747171.png)
