### PR TITLE
Add configuration option to dd-trace library

### DIFF
--- a/src/bin/server.js
+++ b/src/bin/server.js
@@ -1,6 +1,8 @@
+const bootstrap = require('../lib/bootstrap')
 const instrumentation = require('../lib/instrumentation')
 
-instrumentation.initialize()
+bootstrap()
+instrumentation()
 
 const { DatabaseError } = require('../lib/errors')
 const database = require('../database')

--- a/src/bin/worker.js
+++ b/src/bin/worker.js
@@ -1,6 +1,8 @@
+const bootstrap = require('../lib/bootstrap')
 const instrumentation = require('../lib/instrumentation')
 
-instrumentation.initialize()
+bootstrap()
+instrumentation()
 
 const { DatabaseError } = require('../lib/errors')
 const database = require('../database')

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,8 +1,8 @@
 const { prop } = require('ramda')
 
-const { initializeDotEnv } = require('../lib/instrumentation')
+const bootstrap = require('../lib/bootstrap')
 
-initializeDotEnv()
+bootstrap()
 
 const getEnv = env => env || process.env.NODE_ENV || 'test'
 const getConfig = (config, env) => prop(getEnv(env), config)

--- a/src/lib/bootstrap/index.js
+++ b/src/lib/bootstrap/index.js
@@ -1,0 +1,9 @@
+const dotenv = require('dotenv')
+
+const initBootstrap = () => {
+  if (process.env.NODE_ENV === 'production' && process.env.DOTENV_PATH) {
+    dotenv.config({ path: process.env.DOTENV_PATH })
+  }
+}
+
+module.exports = initBootstrap


### PR DESCRIPTION
## Description

Add configuration options to dd-trace library, the default value for the hostname is `localhost` which in this case will be the Datadog agent's load balancer endpoint, the default port is also 8126, I just decided to leave it explicit within the application :) 
<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
