### PR TITLE
server: increase default timeout value

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -32,5 +32,6 @@ app.all('/boletos', defaultHandler)
 app.all('*', defaultResourceHandler)
 
 app.keepAliveTimeout = 61 * 1000
+app.timeout = 60 * 1000
 
 module.exports = app


### PR DESCRIPTION
## Description

Change default timeout value to avoid 5XX errors. These errors
were generated because our ELB idle timeout is longer than the express
default timeout.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
