### PR TITLE
boleto: increase timeout when sending request to Bradesco

### DIFF
--- a/src/resources/boleto/service.js
+++ b/src/resources/boleto/service.js
@@ -41,7 +41,7 @@ module.exports = function boletoService ({ operationId }) {
   const register = (boleto) => {
     const Provider = findProvider(boleto.issuer)
     const provider = Provider.getProvider({ operationId })
-    const timeoutMs = process.env.STAGE === 'live' ? 6000 : 25000
+    const timeoutMs = process.env.STAGE === 'live' ? 10000 : 25000
 
     const logger = makeLogger({ operation: 'register' }, { id: operationId })
 


### PR DESCRIPTION
## Description

Increase timeout when registering a boleto on Bradesco. This PR must be merged in case of bradesco's response time increase during Black Friday.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
