### PR TITLE
boleto: change issuer when boleto-api and interest/fine info

### DIFF
--- a/src/lib/helpers/providers.js
+++ b/src/lib/helpers/providers.js
@@ -1,0 +1,46 @@
+const {
+  isEmpty,
+  isNil,
+  assoc,
+} = require('ramda')
+
+const { makeFromLogger } = require('../logger')
+
+const makeLogger = makeFromLogger('helpers/providers')
+
+const isEmptyOrNull = key => isEmpty(key) || isNil(key)
+
+const changeIssuerWhenInterestOrFine = (boleto) => {
+  const {
+    fine,
+    interest,
+    issuer,
+  } = boleto
+
+  const issuerIsBoletoApi = issuer.includes('boleto-api')
+
+  if (issuerIsBoletoApi && (!isEmptyOrNull(interest) || !isEmptyOrNull(fine))) {
+    const defaultIssuer = 'bradesco'
+
+    const logger = makeLogger({
+      operation: 'change_issuer',
+    })
+
+    logger.info({
+      status: 'success',
+      metadata: {
+        oldIssuer: issuer,
+        newIssuer: defaultIssuer,
+      },
+    })
+
+    return assoc('issuer', defaultIssuer, boleto)
+  }
+
+  return boleto
+}
+
+module.exports = {
+  changeIssuerWhenInterestOrFine,
+  isEmptyOrNull,
+}

--- a/src/resources/boleto/service.js
+++ b/src/resources/boleto/service.js
@@ -9,6 +9,7 @@ const { BoletosToRegisterQueue } = require('./queues')
 const { findProvider } = require('../../providers')
 const { isBradescoOff } = require('../../providers/bradesco/temp')
 const { makeFromLogger } = require('../../lib/logger')
+const { changeIssuerWhenInterestOrFine } = require('../../lib/helpers/providers')
 
 const { Boleto } = database.models
 
@@ -21,6 +22,7 @@ module.exports = function boletoService ({ operationId }) {
     logger.info({ status: 'started', metadata: { data } })
 
     return Promise.resolve(data)
+      .then(changeIssuerWhenInterestOrFine)
       .then(Boleto.create.bind(Boleto))
       .tap((boleto) => {
         logger.info({ status: 'success', metadata: { boleto } })

--- a/test/unit/lib/helper/providers.js
+++ b/test/unit/lib/helper/providers.js
@@ -1,0 +1,196 @@
+import test from 'ava'
+import {
+  isEmptyOrNull,
+  changeIssuerWhenInterestOrFine,
+} from '../../../../src/lib/helpers/providers'
+
+test('isEmptyOrNull: when is not empty or null', async (t) => {
+  const interest = {
+    amount: 100,
+  }
+
+  const result = isEmptyOrNull(interest)
+
+  t.is(result, false)
+})
+
+test('isEmptyOrNull: when is empty and an object', async (t) => {
+  const interest = {}
+
+  const result = isEmptyOrNull(interest)
+
+  t.is(result, true)
+})
+
+test('isEmptyOrNull: when is null', async (t) => {
+  const interest = null
+
+  const result = isEmptyOrNull(interest)
+
+  t.is(result, true)
+})
+
+test('isEmptyOrNull: when is undefined', async (t) => {
+  const interest = undefined
+
+  const result = isEmptyOrNull(interest)
+
+  t.is(result, true)
+})
+
+test('isEmptyOrNull: when is empty and an array', async (t) => {
+  const interest = []
+
+  const result = isEmptyOrNull(interest)
+
+  t.is(result, true)
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is not empty or null and provider is boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    interest: {
+      amount: 200,
+    },
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'bradesco')
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is not empty or null and provider is not boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'development',
+    interest: {
+      amount: 200,
+    },
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'development')
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is empty', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    interest: {},
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is null', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    interest: null,
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
+})
+
+test('changeIssuerWhenInterestOrFine: when fine is not empty or null and provider is boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    fine: {
+      amount: 200,
+    },
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'bradesco')
+})
+
+test('changeIssuerWhenInterestOrFine: when fine is not empty or null and provider is not boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'development',
+    fine: {
+      amount: 200,
+    },
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'development')
+})
+
+test('changeIssuerWhenInterestOrFine: when fine is empty', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    fine: {},
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
+})
+
+test('changeIssuerWhenInterestOrFine: when fine is null', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    fine: null,
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
+})
+
+test('changeIssuerWhenInterestOrFine: when fine is null, interest has info and is boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    fine: null,
+    interest: {
+      amount: 100,
+    },
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'bradesco')
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and is boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'boleto-api-bradesco-shopfacil',
+    fine: {
+      amount: 100,
+    },
+    interest: null,
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'bradesco')
+})
+
+test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and is not boleto-api', async (t) => {
+  const boleto = {
+    amount: 100,
+    issuer: 'development',
+    fine: {
+      amount: 100,
+    },
+    interest: null,
+  }
+
+  const result = changeIssuerWhenInterestOrFine(boleto)
+
+  t.is(result.issuer, 'development')
+})


### PR DESCRIPTION
Dado que a `boleto-api` não suporta registro utilizando informação de juros e multa, precisamos trocar o `issuer` pra `bradesco` quando chegar uma requisição nesse cenário: `issuer: boleto-api-bradesco-shopfacil` e `interest` (juros) ou `fine` (multa) preenchidos.

Relates to https://mundipagg.atlassian.net/browse/GHOST-17