### PR TITLE
change_issuer: add operationId to log

### DIFF
--- a/src/lib/helpers/providers.js
+++ b/src/lib/helpers/providers.js
@@ -10,7 +10,7 @@ const makeLogger = makeFromLogger('helpers/providers')
 
 const isEmptyOrNull = key => isEmpty(key) || isNil(key)
 
-const changeIssuerWhenInterestOrFine = (boleto) => {
+const changeIssuerWhenInterestOrFine = (boleto, operationId) => {
   const {
     fine,
     interest,
@@ -22,9 +22,12 @@ const changeIssuerWhenInterestOrFine = (boleto) => {
   if (issuerIsBoletoApi && (!isEmptyOrNull(interest) || !isEmptyOrNull(fine))) {
     const defaultIssuer = 'bradesco'
 
-    const logger = makeLogger({
-      operation: 'change_issuer',
-    })
+    const logger = makeLogger(
+      {
+        operation: 'change_issuer',
+      },
+      { id: operationId }
+    )
 
     logger.info({
       status: 'success',

--- a/src/resources/boleto/service.js
+++ b/src/resources/boleto/service.js
@@ -22,7 +22,10 @@ module.exports = function boletoService ({ operationId }) {
     logger.info({ status: 'started', metadata: { data } })
 
     return Promise.resolve(data)
-      .then(changeIssuerWhenInterestOrFine)
+      .then(boletoContent => changeIssuerWhenInterestOrFine(
+        boletoContent,
+        operationId
+      ))
       .then(Boleto.create.bind(Boleto))
       .tap((boleto) => {
         logger.info({ status: 'success', metadata: { boleto } })

--- a/test/unit/lib/helper/providers.js
+++ b/test/unit/lib/helper/providers.js
@@ -55,7 +55,7 @@ test('changeIssuerWhenInterestOrFine: when interest is not empty or null and pro
     },
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'bradesco')
 })
@@ -69,7 +69,7 @@ test('changeIssuerWhenInterestOrFine: when interest is not empty or null and pro
     },
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'development')
 })
@@ -81,7 +81,7 @@ test('changeIssuerWhenInterestOrFine: when interest is empty', async (t) => {
     interest: {},
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
 })
@@ -93,7 +93,7 @@ test('changeIssuerWhenInterestOrFine: when interest is null', async (t) => {
     interest: null,
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
 })
@@ -107,7 +107,7 @@ test('changeIssuerWhenInterestOrFine: when fine is not empty or null and provide
     },
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'bradesco')
 })
@@ -145,7 +145,7 @@ test('changeIssuerWhenInterestOrFine: when fine is null', async (t) => {
     fine: null,
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'boleto-api-bradesco-shopfacil')
 })
@@ -160,7 +160,7 @@ test('changeIssuerWhenInterestOrFine: when fine is null, interest has info and i
     },
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'bradesco')
 })
@@ -175,7 +175,7 @@ test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and i
     interest: null,
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'bradesco')
 })
@@ -190,7 +190,7 @@ test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and i
     interest: null,
   }
 
-  const result = changeIssuerWhenInterestOrFine(boleto)
+  const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
 
   t.is(result.issuer, 'development')
 })


### PR DESCRIPTION
## Description

Verificamos que o log de [`change_issuer`](https://github.com/pagarme/superbowleto/blob/master/src/lib/helpers/providers.js#L29) não estava sendo agrupado junto aos outros logs dos boletos. Para corrigir isso, é necessário passar o `operationId` do fluxo padrão para a função, e instanciar o log passando o `operationId`

Relates to GHOST-28

