### PR TITLE
Configuration: add logic to find boleto config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   migrate:
     build: .
-    entrypoint: node_modules/.bin/sequelize db:migrate --config src/config/database.js --migrations-path src/database/migrations/
+    entrypoint: npm run migrate_seed
     environment:
       - API_ENV=test
     volumes:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "test-e2e": "ava --verbose --serial 'test/e2e/**/*.js'",
     "test-functional": "ava --verbose --serial 'test/functional/**/*.js'",
     "test-integration": "ava --verbose 'test/integration/**/*.js'",
-    "test-unit": "ava --verbose 'test/unit/**/*.js'"
+    "test-unit": "ava --verbose 'test/unit/**/*.js'",
+    "migrate": "node_modules/.bin/sequelize db:migrate --config src/config/database.js --migrations-path src/database/migrations/",
+    "seed": "node_modules/.bin/sequelize db:seed:all --config src/config/database.js --seeders-path src/database/seeders/",
+    "migrate_seed": "npm run migrate && npm run seed"
   },
   "repository": {
     "type": "git",

--- a/src/database/migrations/20200709000000-add-external-id-to-boleto.js
+++ b/src/database/migrations/20200709000000-add-external-id-to-boleto.js
@@ -1,0 +1,11 @@
+const { STRING } = require('sequelize')
+
+module.exports = {
+  up: queryInterface =>
+    queryInterface.addColumn('Boletos', 'external_id', {
+      type: STRING,
+    }),
+
+  down: queryInterface =>
+    queryInterface.removeColumn('Boletos', 'external_id'),
+}

--- a/src/database/migrations/20200804000000-add-rules-to-boleto.js
+++ b/src/database/migrations/20200804000000-add-rules-to-boleto.js
@@ -1,0 +1,14 @@
+const {
+  ARRAY,
+  TEXT,
+} = require('sequelize')
+
+module.exports = {
+  up: queryInterface =>
+    queryInterface.addColumn('Boletos', 'rules', {
+      type: ARRAY(TEXT),
+    }),
+
+  down: queryInterface =>
+    queryInterface.removeColumn('Boletos', 'rules'),
+}

--- a/src/database/seeders/20200707213655-configuration.js
+++ b/src/database/seeders/20200707213655-configuration.js
@@ -1,0 +1,18 @@
+const now = new Date()
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.bulkDelete('Configurations', null)
+    return queryInterface.bulkInsert('Configurations', [{
+      id: 'cf_niskhinfjsihfjisALINETHORjmsijdisag',
+      external_id: 'pagarme',
+      issuer_account: '9721',
+      issuer_agency: '3381',
+      issuer_wallet: '26',
+      issuer: 'bradesco',
+      created_at: now,
+      updated_at: now,
+    }])
+  },
+  down: queryInterface => queryInterface.bulkDelete('Configurations', null),
+}

--- a/src/lib/helpers/configurations.js
+++ b/src/lib/helpers/configurations.js
@@ -1,0 +1,50 @@
+const database = require('../../database')
+const {
+  merge,
+} = require('ramda')
+
+const { Configuration } = database.models
+
+const findBoletoConfiguration = async (boleto) => {
+  const {
+    external_id: externalId,
+  } = boleto
+
+  const defaultId = 'pagarme'
+  let configuration
+
+  if (externalId) {
+    configuration = await Configuration.findOne({
+      where: {
+        external_id: externalId,
+      },
+      raw: true,
+    })
+  }
+
+  if (!configuration) {
+    configuration = await Configuration.findOne({
+      where: {
+        external_id: defaultId,
+      },
+      raw: true,
+    })
+  }
+
+  if (!configuration) {
+    return boleto
+  }
+
+  const updatedRequestConfig = {
+    issuer: configuration.issuer,
+    issuer_account: configuration.issuer_account,
+    issuer_agency: configuration.issuer_agency,
+    issuer_wallet: configuration.issuer_wallet,
+  }
+
+  return merge(boleto, updatedRequestConfig)
+}
+
+module.exports = {
+  findBoletoConfiguration,
+}

--- a/src/lib/helpers/configurations.js
+++ b/src/lib/helpers/configurations.js
@@ -45,6 +45,26 @@ const findBoletoConfiguration = async (boleto) => {
   return merge(boleto, updatedRequestConfig)
 }
 
+const setBoletoRulesConfiguration = (boleto) => {
+  const config = {
+    issuer: 'bradesco',
+    issuer_account: '469',
+    issuer_agency: '1229',
+  }
+
+  if (boleto.rules) {
+    if (boleto.rules.includes('strict_expiration_date')) {
+      return merge(boleto, { ...config, issuer_wallet: '25' })
+    }
+    if (boleto.rules.includes('no_strict')) {
+      return merge(boleto, { ...config, issuer_wallet: '26' })
+    }
+  }
+
+  return findBoletoConfiguration(boleto)
+}
+
 module.exports = {
+  setBoletoRulesConfiguration,
   findBoletoConfiguration,
 }

--- a/src/resources/boleto/model.js
+++ b/src/resources/boleto/model.js
@@ -73,6 +73,7 @@ const buildModelResponse = responseObjectBuilder(boleto =>
       'payer_document_type',
       'payer_document_number',
       'payer_address',
+      'external_id',
       'company_name',
       'company_document_number',
       'company_address',
@@ -256,6 +257,11 @@ function create (database) {
 
     payer_address: {
       type: JSON,
+    },
+
+    external_id: {
+      type: STRING,
+      allowNull: true,
     },
 
     company_name: {

--- a/src/resources/boleto/model.js
+++ b/src/resources/boleto/model.js
@@ -19,7 +19,7 @@ const {
 } = require('ramda')
 
 const {
-  STRING, INTEGER, ENUM, TEXT, DATE, JSON,
+  STRING, INTEGER, ENUM, TEXT, DATE, JSON, ARRAY,
 } = require('sequelize')
 const { Boleto: NodeBoleto } = require('node-boleto')
 const { defaultCuidValue, responseObjectBuilder } = require('../../lib/database/schema')
@@ -78,6 +78,7 @@ const buildModelResponse = responseObjectBuilder(boleto =>
       'company_document_number',
       'company_address',
       'bank_response_code',
+      'rules',
       'reference_id',
       'created_at',
       'updated_at',
@@ -284,6 +285,11 @@ function create (database) {
 
     issuer_response_code: {
       type: STRING,
+    },
+
+    rules: {
+      type: ARRAY(TEXT),
+      allowNull: true,
     },
   }, {
     indexes: [

--- a/src/resources/boleto/schema.js
+++ b/src/resources/boleto/schema.js
@@ -91,6 +91,11 @@ const createSchema = {
     .allow(null)
     .allow(''),
 
+  external_id: Joi
+    .string()
+    .allow(null)
+    .allow(''),
+
   company_address: Joi.object().keys({
     zipcode: Joi
       .string()

--- a/src/resources/boleto/schema.js
+++ b/src/resources/boleto/schema.js
@@ -193,6 +193,11 @@ const createSchema = {
   register: Joi
     .boolean()
     .default(true),
+
+  rules: Joi
+    .array()
+    .allow(null)
+    .items(Joi.string().valid('strict_expiration_date', 'no_strict')),
 }
 
 const updateSchema = {

--- a/src/resources/boleto/service.js
+++ b/src/resources/boleto/service.js
@@ -10,6 +10,7 @@ const { findProvider } = require('../../providers')
 const { isBradescoOff } = require('../../providers/bradesco/temp')
 const { makeFromLogger } = require('../../lib/logger')
 const { changeIssuerWhenInterestOrFine } = require('../../lib/helpers/providers')
+const { setBoletoRulesConfiguration } = require('../../lib/helpers/configurations')
 
 const { Boleto } = database.models
 
@@ -22,6 +23,7 @@ module.exports = function boletoService ({ operationId }) {
     logger.info({ status: 'started', metadata: { data } })
 
     return Promise.resolve(data)
+      .then(setBoletoRulesConfiguration)
       .then(boletoContent => changeIssuerWhenInterestOrFine(
         boletoContent,
         operationId

--- a/test/functional/configuration/authentication.js
+++ b/test/functional/configuration/authentication.js
@@ -3,13 +3,23 @@ import cuid from 'cuid'
 import { merge } from 'ramda'
 import { mock } from '../../helpers/configuration'
 import request from '../../helpers/request'
+import database from '../../../src/database'
+
+const { Configuration } = database.models
+const externalId = cuid()
+
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
+})
 
 test('POST /configurations with authentication', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body, statusCode } = await request({
@@ -26,11 +36,9 @@ test('POST /configurations with authentication', async (t) => {
 })
 
 test('POST /configurations with invalid authentication', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body, statusCode } = await request({
@@ -55,11 +63,9 @@ test('POST /configurations with invalid authentication', async (t) => {
 })
 
 test('POST /configurations without authentication', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body, statusCode } = await request({

--- a/test/functional/configuration/create.js
+++ b/test/functional/configuration/create.js
@@ -7,17 +7,20 @@ import request from '../../helpers/request'
 import database from '../../../src/database'
 
 const { Configuration } = database.models
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('POST /configurations', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body, statusCode } = await request({
@@ -33,7 +36,7 @@ test('POST /configurations', async (t) => {
   t.is(body.object, 'configuration')
 
   assert.containSubset(body, {
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
     issuer_account: mock.issuer_account,
     issuer_agency: mock.issuer_agency,

--- a/test/functional/configuration/show.js
+++ b/test/functional/configuration/show.js
@@ -7,20 +7,23 @@ import { mock } from '../../helpers/configuration'
 import database from '../../../src/database'
 
 const { Configuration } = database.models
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('GET /configurations/:id with valid id', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
-  const { body: { external_id: externalId } } = await request({
+  await request({
     route: '/configurations',
     method: 'POST',
     data: configuration,
@@ -38,11 +41,11 @@ test('GET /configurations/:id with valid id', async (t) => {
   })
 
   t.is(statusCode, 200)
-  t.is(body.external_id, companyId)
+  t.is(body.external_id, externalId)
   t.is(body.object, 'configuration')
 
   assert.containSubset(body, {
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
     issuer_account: mock.issuer_account,
     issuer_agency: mock.issuer_agency,

--- a/test/functional/configuration/update.js
+++ b/test/functional/configuration/update.js
@@ -7,17 +7,20 @@ import { mock } from '../../helpers/configuration'
 import database from '../../../src/database'
 
 const { Configuration } = database.models
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('PATCH /configurations/:external_id', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body: { id } } = await request({
@@ -44,7 +47,7 @@ test('PATCH /configurations/:external_id', async (t) => {
   t.is(body.object, 'configuration')
 
   assert.containSubset(body, {
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'boleto-api-bradesco-shopfacil',
     issuer_account: mock.issuer_account,
     issuer_agency: mock.issuer_agency,
@@ -53,11 +56,9 @@ test('PATCH /configurations/:external_id', async (t) => {
 })
 
 test('PATCH /configurations/:id with invalid parameters', async (t) => {
-  const companyId = cuid()
-
   const configuration = merge(mock, {
     issuer: 'bradesco',
-    external_id: companyId,
+    external_id: externalId,
   })
 
   const { body: { id } } = await request({

--- a/test/integration/boleto/create.js
+++ b/test/integration/boleto/create.js
@@ -11,6 +11,7 @@ test('creates a boleto with invalid data', async (t) => {
     expiration_date: true,
     issuer: 100,
     payer_document_type: 'xxx',
+    rules: 123,
   }
 
   const { body, statusCode } = await create({
@@ -47,6 +48,10 @@ test('creates a boleto with invalid data', async (t) => {
       type: 'invalid_parameter',
       message: '"payer_document_number" is required',
       field: 'payer_document_number',
+    }, {
+      type: 'invalid_parameter',
+      message: '"rules" must be an array',
+      field: 'rules',
     }],
   })
 })

--- a/test/integration/boleto/create/boleto-api-bradesco-shopfacil/registered.js
+++ b/test/integration/boleto/create/boleto-api-bradesco-shopfacil/registered.js
@@ -57,3 +57,41 @@ test('creates a boleto (status success)', async (t) => {
     queue_url: payload.queue_url,
   })
 })
+
+test('creates a boleto with rules: changing issuer to bradesco', async (t) => {
+  const payload = mock
+
+  payload.issuer = 'boleto-api-bradesco-shopfacil'
+  payload.rules = ['no_strict']
+  payload.external_id = externalId
+  payload.interest = undefined
+  payload.fine = undefined
+
+  const { body, statusCode } = await create({
+    body: payload,
+  })
+
+  t.is(statusCode, 201)
+  t.is(body.object, 'boleto')
+  t.is(body.issuer, 'bradesco')
+  t.is(body.issuer_wallet, '26')
+
+  t.true(body.title_id != null)
+  t.true(body.barcode != null)
+  t.true(typeof body.title_id === 'number')
+
+  assert.containSubset(body, {
+    status: 'registered',
+    paid_amount: 0,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    issuer: 'bradesco',
+    issuer_id: null,
+    payer_name: payload.payer_name,
+    payer_document_type: payload.payer_document_type,
+    payer_document_number: payload.payer_document_number,
+    company_name: payload.company_name,
+    company_document_number: payload.company_document_number,
+    queue_url: payload.queue_url,
+  })
+})

--- a/test/integration/boleto/create/boleto-api-bradesco-shopfacil/registered.js
+++ b/test/integration/boleto/create/boleto-api-bradesco-shopfacil/registered.js
@@ -1,14 +1,24 @@
 import test from 'ava'
 import Promise from 'bluebird'
+import cuid from 'cuid'
 import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock, mockFunction, restoreFunction } from '../../../../helpers/boleto'
 import boletoHandler from '../../../../../src/resources/boleto'
 import Provider from '../../../../../src/providers/boleto-api-bradesco-shopfacil'
+import { createConfig } from '../../../../helpers/configuration'
+import database from '../../../../../src/database'
 
+const { Configuration } = database.models
 const create = normalizeHandler(boletoHandler.create)
+const externalId = cuid()
 
-test.before(() => {
+test.before(async () => {
+  await createConfig({
+    issuer: 'boleto-api-bradesco-shopfacil',
+    external_id: externalId,
+  })
+
   mockFunction(Provider, 'getProvider', () => ({
     register () {
       return Promise.resolve({
@@ -21,12 +31,18 @@ test.before(() => {
 
 test.after(async () => {
   restoreFunction(Provider, 'getProvider')
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('creates a boleto (status success)', async (t) => {
   const payload = mock
 
   payload.issuer = 'boleto-api-bradesco-shopfacil'
+  payload.external_id = externalId
   payload.interest = undefined
   payload.fine = undefined
 

--- a/test/integration/boleto/create/development/pending.js
+++ b/test/integration/boleto/create/development/pending.js
@@ -1,16 +1,37 @@
 import test from 'ava'
+import cuid from 'cuid'
 import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock } from '../../../../helpers/boleto'
 import boletoHandler from '../../../../../src/resources/boleto'
+import { createConfig } from '../../../../helpers/configuration'
+import database from '../../../../../src/database'
 
+const { Configuration } = database.models
 const create = normalizeHandler(boletoHandler.create)
+const externalId = cuid()
+
+test.before(async () => {
+  await createConfig({
+    issuer: 'development',
+    external_id: externalId,
+  })
+})
+
+test.after(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
+})
 
 test('creates a boleto (provider unknown)', async (t) => {
   const payload = mock
 
   payload.amount = 5000003
   payload.issuer = 'development'
+  payload.external_id = externalId
 
   const { body, statusCode } = await create({
     body: payload,

--- a/test/integration/boleto/create/development/refused.js
+++ b/test/integration/boleto/create/development/refused.js
@@ -1,16 +1,37 @@
 import test from 'ava'
+import cuid from 'cuid'
 import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock } from '../../../../helpers/boleto'
 import boletoHandler from '../../../../../src/resources/boleto'
+import { createConfig } from '../../../../helpers/configuration'
+import database from '../../../../../src/database'
 
+const { Configuration } = database.models
 const create = normalizeHandler(boletoHandler.create)
+const externalId = cuid()
+
+test.before(async () => {
+  await createConfig({
+    issuer: 'development',
+    external_id: externalId,
+  })
+})
+
+test.after(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
+})
 
 test('creates a boleto (provider refused)', async (t) => {
   const payload = mock
 
   payload.amount = 5000004
   payload.issuer = 'development'
+  payload.external_id = externalId
 
   const { body, statusCode } = await create({
     body: payload,

--- a/test/integration/boleto/create/development/registered.js
+++ b/test/integration/boleto/create/development/registered.js
@@ -1,16 +1,37 @@
 import test from 'ava'
+import cuid from 'cuid'
 import { assert } from '../../../../helpers/chai'
 import { normalizeHandler } from '../../../../helpers/normalizer'
 import { mock } from '../../../../helpers/boleto'
 import boletoHandler from '../../../../../src/resources/boleto'
+import { createConfig } from '../../../../helpers/configuration'
+import database from '../../../../../src/database'
 
+const { Configuration } = database.models
 const create = normalizeHandler(boletoHandler.create)
+const externalId = cuid()
+
+test.before(async () => {
+  await createConfig({
+    issuer: 'development',
+    external_id: externalId,
+  })
+})
+
+test.after(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
+})
 
 test('creates a boleto (provider success)', async (t) => {
   const payload = mock
 
   payload.amount = 5000000
   payload.issuer = 'development'
+  payload.external_id = externalId
 
   const { body, statusCode } = await create({
     body: payload,

--- a/test/integration/configuration/create.js
+++ b/test/integration/configuration/create.js
@@ -2,23 +2,26 @@ import cuid from 'cuid'
 import test from 'ava'
 import { assert } from '../../helpers/chai'
 import { normalizeHandler } from '../../helpers/normalizer'
-import { mock } from '../../helpers/configuration'
+import { mock } from '../../helpers/configuration/index'
 import configHandler from '../../../src/resources/configuration'
 import database from '../../../src/database'
 
 const { Configuration } = database.models
 const create = normalizeHandler(configHandler.create)
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('creates a configuration', async (t) => {
-  const companyId = cuid()
-
   const payload = mock
 
-  payload.external_id = companyId
+  payload.external_id = externalId
   payload.issuer = 'bradesco'
 
   const { body, statusCode } = await create({

--- a/test/integration/configuration/show.js
+++ b/test/integration/configuration/show.js
@@ -8,31 +8,34 @@ import database from '../../../src/database'
 
 const { Configuration } = database.models
 const showConfig = normalizeHandler(configurationHandler.show)
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('shows an existing configuration', async (t) => {
-  const companyId = cuid()
-
   const configuration = await createConfig({
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
   })
 
   const { body, statusCode } = await showConfig({
     params: {
-      external_id: companyId,
+      external_id: externalId,
     },
   })
 
   t.is(statusCode, 200)
-  t.is(body.external_id, companyId)
+  t.is(body.external_id, externalId)
   t.is(body.object, 'configuration')
 
   assert.containSubset(body, {
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
     issuer_account: configuration.issuer_account,
     issuer_agency: configuration.issuer_agency,

--- a/test/integration/configuration/update.js
+++ b/test/integration/configuration/update.js
@@ -8,16 +8,19 @@ import database from '../../../src/database'
 
 const { Configuration } = database.models
 const updateConfig = normalizeHandler(configurationHandler.update)
+const externalId = cuid()
 
-test.after(async () => {
-  await Configuration.destroy({ where: {} })
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
 })
 
 test('Update configuration: issuer and issuer_agency', async (t) => {
-  const companyId = cuid()
-
   const configuration = await createConfig({
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
   })
 
@@ -35,7 +38,7 @@ test('Update configuration: issuer and issuer_agency', async (t) => {
   t.is(body.object, 'configuration')
 
   assert.containSubset(body, {
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'boleto-api-bradesco-shopfacil',
     issuer_account: configuration.issuer_account,
     issuer_agency: '5555',
@@ -44,10 +47,8 @@ test('Update configuration: issuer and issuer_agency', async (t) => {
 })
 
 test('try to update configuration with invalid issuer', async (t) => {
-  const companyId = cuid()
-
   const configuration = await createConfig({
-    external_id: companyId,
+    external_id: externalId,
     issuer: 'bradesco',
   })
 

--- a/test/integration/lib/helper/configurations.js
+++ b/test/integration/lib/helper/configurations.js
@@ -1,0 +1,88 @@
+import test from 'ava'
+import cuid from 'cuid'
+import { assert } from '../../../helpers/chai'
+import { mock } from '../../../helpers/boleto'
+import { findBoletoConfiguration } from '../../../../src/lib/helpers/configurations'
+import { createConfig } from '../../../helpers/configuration'
+import database from '../../../../src/database'
+
+const { Configuration } = database.models
+const externalId = cuid()
+
+test.afterEach(async () => {
+  await Configuration.destroy({
+    where: {
+      external_id: externalId,
+    },
+  })
+})
+
+test('findBoletoConfiguration: without configuration created', async (t) => {
+  const payload = mock
+
+  payload.external_id = externalId
+  payload.issuer = 'boleto-api-bradesco-shopfacil'
+
+  const boleto = await findBoletoConfiguration(payload)
+
+  t.is(boleto.issuer, 'bradesco')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})
+
+test('findBoletoConfiguration: without externalId', async (t) => {
+  const payload = mock
+
+  payload.external_id = undefined
+  payload.issuer = 'boleto-api-bradesco-shopfacil'
+
+  const boleto = await findBoletoConfiguration(payload)
+
+  t.is(boleto.issuer, 'bradesco')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})
+
+test('findBoletoConfiguration: with configuration created', async (t) => {
+  await createConfig({
+    issuer: 'boleto-api-bradesco-shopfacil',
+    external_id: externalId,
+  })
+
+  const payload = mock
+
+  payload.external_id = externalId
+
+  const boleto = await findBoletoConfiguration(payload)
+
+  t.is(boleto.issuer, 'boleto-api-bradesco-shopfacil')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})

--- a/test/unit/lib/helper/configurations.js
+++ b/test/unit/lib/helper/configurations.js
@@ -1,0 +1,71 @@
+import test from 'ava'
+import { assert } from '../../../helpers/chai'
+import { mock } from '../../../helpers/boleto'
+import { setBoletoRulesConfiguration } from '../../../../src/lib/helpers/configurations'
+
+test('setBoletoRulesConfiguration: without rules', async (t) => {
+  const payload = mock
+
+  payload.rules = null
+  payload.issuer = 'boleto-api-bradesco-shopfacil'
+
+  const boleto = await setBoletoRulesConfiguration(payload)
+
+  t.is(boleto.issuer_wallet, '26')
+  t.is(boleto.issuer, 'bradesco')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})
+
+test('setBoletoRulesConfiguration: no_strict', async (t) => {
+  const payload = mock
+
+  payload.rules = ['no_strict']
+
+  const boleto = await setBoletoRulesConfiguration(payload)
+
+  t.is(boleto.issuer_wallet, '26')
+  t.is(boleto.issuer, 'bradesco')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})
+
+test('setBoletoRulesConfiguration: strict_expiration_date', async (t) => {
+  const payload = mock
+
+  payload.rules = ['strict_expiration_date']
+
+  const boleto = await setBoletoRulesConfiguration(payload)
+
+  t.is(boleto.issuer_wallet, '25')
+  t.is(boleto.issuer, 'bradesco')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})


### PR DESCRIPTION
Este PR visa tirar algumas responsabilidades do [boleto-processor](https://github.com/pagarme/pagarme-core/blob/master/gateway/lib/environments/pagarme/boleto-processor.js) do gateway e inserir uma nova lógica ao superbowleto.

Segue as etapas que foram adicionadas ao chegar uma requisição:
- verificar se a requisição chegou com `boleto.rules` preenchido, se sim deve-se considerar a carteira de acordo com a regra escolhida. (isso atualmente é feito no [boleto-processor](https://github.com/pagarme/pagarme-core/blob/25251eea560f58d9d70c35a779123684a03f44a7/gateway/lib/environments/pagarme/boleto-processor.js#L61), mas mudamos para o superbowleto)
- caso não tenha `boleto.rules` devemos buscar as configurações de registro daquela company na model de [Configurations](https://github.com/pagarme/superbowleto/pull/338), e se não encontrar, usar a configuração default `pagarme` que foi adicionada como uma seed para ser usada nos testes.
- para facilitar a virada para essa nova lógica, consideramos também que se não tiver uma configuração default, permanecem as informações que foram enviadas na requisição. Porém isso é apenas para facilitar por enquanto, pois no futuro vamos parar de receber essas informações do gateway e buscar apenas na tabela de `Configurations`.

Pontos de atenção:
- para conseguir resgatar as configurações da company, precisamos passar a enviar o `company.id` e também o campo de `boleto.rules` do gateway para o Superbowleto. 
- alterei os testes de integração para se adaptarem a lógica nova de configurações. Os testes do `bradesco` não foram alterados, pois como a configuração default é Bradesco, quis garantir que esse comportamento também estava funcionando.
 
peace :peace_symbol: 

relates to https://mundipagg.atlassian.net/browse/PGHOST-25


