### PR TITLE
bradesco: retry boleto

### DIFF
--- a/src/providers/boleto-api-bradesco-shopfacil/response-codes.js
+++ b/src/providers/boleto-api-bradesco-shopfacil/response-codes.js
@@ -621,7 +621,7 @@ module.exports = {
   },
   93005999: {
     message: 'BOLETO GERADO COM SUCESSO – REGISTRO EM PROCESSAMENTO',
-    status: 'registered',
+    status: 'unknown',
   },
   '-549': {
     message: 'Erro - A Tag DATAVENCIMENTO do Boleto nao pode ser alterada quando o titulo ja foi registrado',

--- a/src/providers/bradesco/response-codes.js
+++ b/src/providers/bradesco/response-codes.js
@@ -489,6 +489,6 @@ module.exports = {
   },
   93005999: {
     message: 'BOLETO GERADO COM SUCESSO - REGISTRO EM PROCESSAMENTO',
-    status: 'registered',
+    status: 'unknown',
   },
 }

--- a/test/integration/boleto/create/bradesco/pending.js
+++ b/test/integration/boleto/create/bradesco/pending.js
@@ -15,7 +15,7 @@ test.before(async () => {
     register () {
       return Promise.resolve({
         status: 'unknown',
-        issuer_response_code: 'unknown',
+        issuer_response_code: '93005999',
       })
     },
   }))
@@ -49,7 +49,7 @@ test('creates a boleto (provider unknown)', async (t) => {
 
   assert.containSubset(body, {
     status: 'pending_registration',
-    issuer_response_code: 'unknown',
+    issuer_response_code: '93005999',
     paid_amount: 0,
     amount: payload.amount,
     instructions: payload.instructions,


### PR DESCRIPTION
Quando Bradesco retornar com 93005999 - BOLETO GERADO COM SUCESSO - REGISTRO EM PROCESSAMENTO precisamos adicionar o boleto na fila de retentativa de registro. Para fazer isso, basta mudar o status dessa resposta para "unknown" ao invés de "registered".

Estamos fazendo esse fix, pois houveram casos em que o bradesco não finalizou o registro dos boletos retornados assim.

Para monitorar: 
[Dash boletos](https://app.datadoghq.com/dashboard/2va-q6a-rni/boleto?from_ts=1590682833859&live=true&to_ts=1590686433859) 
[Registros em processamento](https://app.datadoghq.com/logs?cols=%40latency%2Chost%2C%40body.error.message&from_ts=1606129959816&index=&live=true&messageDisplay=inline&query=env%3Aproduction+service%3Asuperbowleto++%40data.message.metadata.response.status.mensagem%3A%22BOLETO+GERADO+COM+SUCESSO+-+REGISTRO+EM+PROCESSAMENTO%22&stream_sort=desc&to_ts=1606133559816)

Relates to https://mundipagg.atlassian.net/browse/PGHOST-108