### PR TITLE
boleto index: drop and create again

### DIFF
--- a/script/start.sh
+++ b/script/start.sh
@@ -8,13 +8,13 @@ sh -c /entrypoint.sh
 
 if [ $APP_TYPE = "worker" ]
 then
+  #run migrations
+  echo "call migrations"
+  /app/node_modules/.bin/sequelize db:migrate --config /app/src/config/database.js --migrations-path /app/src/database/migrations/
   # run worker
   echo "call worker service"
   node /app/src/bin/worker.js
 else
-  #run migrations
-  echo "call migrations"
-  /app/node_modules/.bin/sequelize db:migrate --config /app/src/config/database.js --migrations-path /app/src/database/migrations/
   #run server
   echo "call server service"
   node /app/src/bin/server.js

--- a/src/database/migrations/20201208134000-drop-index-title-id-in-boleto.js
+++ b/src/database/migrations/20201208134000-drop-index-title-id-in-boleto.js
@@ -1,0 +1,12 @@
+const index = 'ix_title_id'
+
+module.exports = {
+  up (queryInterface) {
+    return queryInterface.sequelize.query(`
+    DROP INDEX CONCURRENTLY IF EXISTS
+    ${index};
+  `)
+  },
+
+  down () { },
+}

--- a/src/database/migrations/20201208134100-create-index-title-id-to-boleto.js
+++ b/src/database/migrations/20201208134100-create-index-title-id-to-boleto.js
@@ -1,0 +1,20 @@
+const index = 'ix_title_id'
+const table = 'Boletos'
+const column = 'title_id'
+
+module.exports = {
+  up (queryInterface) {
+    return queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS
+      ${index} ON "${table}"
+      USING btree (${column});
+    `)
+  },
+
+  down (queryInterface) {
+    return queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS
+      ${index};
+    `)
+  },
+}

--- a/src/database/migrations/20201208134130-drop-index-token-in-boleto.js
+++ b/src/database/migrations/20201208134130-drop-index-token-in-boleto.js
@@ -1,0 +1,12 @@
+const index = 'ix_token'
+
+module.exports = {
+  up (queryInterface) {
+    return queryInterface.sequelize.query(`
+    DROP INDEX CONCURRENTLY IF EXISTS
+    ${index};
+  `)
+  },
+
+  down () { },
+}

--- a/src/database/migrations/20201208134200-create-index-token-to-boleto.js
+++ b/src/database/migrations/20201208134200-create-index-token-to-boleto.js
@@ -1,0 +1,20 @@
+const index = 'ix_token'
+const table = 'Boletos'
+const column = 'token'
+
+module.exports = {
+  up (queryInterface) {
+    return queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS
+      ${index} ON "${table}"
+      USING btree (${column});
+    `)
+  },
+
+  down (queryInterface) {
+    return queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS
+      ${index};
+    `)
+  },
+}


### PR DESCRIPTION
Com o problema que tivemos no deploy da renderização do boleto caixa, foi verificado que havia dois indíces com problemas no db do Superbowleto. Por isso, vamos removê-los e criá-los de novamente.