### PR TITLE
Add allow unknown get parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "4.14.0",
     "eslint-config-pagarme-base": "2.0.0",
     "eslint-plugin-import": "2.14.0",
+    "nock": "13.0.5",
     "nyc": "13.1.0",
     "sinon": "2.3.2",
     "tap-xunit": "2.4.1"

--- a/src/lib/http/request.js
+++ b/src/lib/http/request.js
@@ -2,9 +2,14 @@ const { curryN } = require('ramda')
 const Joi = require('joi')
 const { ValidationError, InvalidParameterError } = require('../errors')
 
-const parse = curryN(2, (schema, data) => new Promise((resolve, reject) => {
+const parse = curryN(2, (
+  schema,
+  data,
+  specificOptions = {}
+) => new Promise((resolve, reject) => {
   const options = {
     abortEarly: false,
+    ...specificOptions,
   }
 
   const { error, value } = Joi.validate(data, schema, options)

--- a/src/resources/boleto/index.js
+++ b/src/resources/boleto/index.js
@@ -124,8 +124,12 @@ const index = (req, res) => {
 
   const { query } = req
 
+  const specificJoiValidateOptions = {
+    allowUnknown: true,
+  }
+
   return Promise.resolve(query)
-    .then(parse(indexSchema))
+    .then(parse(indexSchema, query, specificJoiValidateOptions))
     .then(service.index)
     .then(buildModelResponse)
     .then(buildSuccessResponse(200))

--- a/src/resources/boleto/index.js
+++ b/src/resources/boleto/index.js
@@ -122,7 +122,11 @@ const index = (req, res) => {
   const requestId = req.get('x-request-id') || defaultCuidValue('req_')()
   const service = BoletoService({ operationId: requestId })
 
+  const logger = makeLogger({ operation: 'handle_boleto_index_request' }, { id: requestId })
+
   const { query } = req
+
+  logger.info({ status: 'started', metadata: { query } })
 
   const specificJoiValidateOptions = {
     allowUnknown: true,
@@ -133,7 +137,27 @@ const index = (req, res) => {
     .then(service.index)
     .then(buildModelResponse)
     .then(buildSuccessResponse(200))
-    .catch(handleError)
+    .tap((response) => {
+      logger.info({
+        status: 'success',
+        metadata: {
+          body: response.body,
+          statusCode: response.statusCode,
+        },
+      })
+    })
+    .catch((err) => {
+      logger.error({
+        status: 'failed',
+        metadata: {
+          error_name: err.name,
+          error_stack: err.stack,
+          error_message: err.message,
+        },
+      })
+
+      return handleError(err)
+    })
     .tap(({ body, statusCode }) => res.status(statusCode).send(body))
 }
 

--- a/test/functional/boletos/index.js
+++ b/test/functional/boletos/index.js
@@ -80,3 +80,36 @@ test('GET /boletos with count', async (t) => {
     company_document_number: '98154524872',
   }, 'result must have the shape of a boleto')
 })
+
+test('GET /boletos with unknown parameters', async (t) => {
+  const { body, statusCode } = await request({
+    route: '/boletos?a="a"&b=2&c="c"',
+    method: 'GET',
+    headers: {
+      'x-api-key': 'abc123',
+    },
+  })
+
+  t.is(statusCode, 200)
+  t.true(is(Array, body))
+  t.is(body.length, 10)
+
+  const item = body[0]
+
+  t.is(item.object, 'boleto')
+
+  assert.containSubset(item, {
+    status: 'issued',
+    paid_amount: 0,
+    amount: 2000,
+    instructions: 'Please do not accept after expiration_date',
+    issuer: 'bradesco',
+    issuer_id: null,
+    payer_name: 'David Bowie',
+    payer_document_type: 'cpf',
+    payer_document_number: '98154524872',
+    queue_url: userQueueUrl,
+    company_name: 'Some Company',
+    company_document_number: '98154524872',
+  }, 'result must have the shape of a boleto')
+})

--- a/test/unit/lib/http/request.js
+++ b/test/unit/lib/http/request.js
@@ -37,6 +37,57 @@ test('parse: with valid schema and coercion', async (t) => {
   }, 'should have the correct parsed, coerced parameters and no errors')
 })
 
+test('parse: with valid schema and specific validate options allowUnknown true', async (t) => {
+  const specificJoiValidateOptions = {
+    allowUnknown: true,
+  }
+
+  const value = await parse(schema, {
+    name: 'David Bowie',
+    security_number: 42,
+    a: 'a',
+    b: 'b',
+  }, specificJoiValidateOptions)
+
+  t.deepEqual(value, {
+    name: 'David Bowie',
+    security_number: 42,
+    a: 'a',
+    b: 'b',
+  }, 'should have the correct parsed parameters and no errors')
+})
+
+test('parse: with valid schema and specific validate options allowUnknown false', async (t) => {
+  const specificJoiValidateOptions = {
+    allowUnknown: false,
+  }
+
+  const validationError = await parse(schema, {
+    name: 'David Bowie',
+    security_number: 42,
+    a: 'a',
+    b: 'b',
+  }, specificJoiValidateOptions).catch(err => err)
+
+  const { errors } = validationError
+
+  t.true(validationError instanceof ValidationError, 'should be a ValidationError')
+  t.true(Array.isArray(errors), 'should have an array of errors')
+  t.is(errors.length, 2, 'should have 2 errors')
+
+  assert.containSubset(errors[0], {
+    message: '"a" is not allowed',
+    type: 'invalid_parameter',
+    field: 'a',
+  }, 'should have an error because `a` is anknown')
+
+  assert.containSubset(errors[1], {
+    message: '"b" is not allowed',
+    type: 'invalid_parameter',
+    field: 'b',
+  }, 'should have an error because `b` is anknown')
+})
+
 test('parse: with invalid schema', async (t) => {
   const validationError = await parse(schema, {
     security_number: true,


### PR DESCRIPTION
## Descrição do problema

Analisando algumas requests com erro no DataDog, identificamos que, no caso das requisições get realizadas no endpoint `/boletos/:id` alguns erros estão ocorrendo devido ao envio de parâmetros query desconhecidos, ou seja, parâmetros que não estão no schema de validação `indexSchema` do Joi.

[Logs do caso em questão](https://app.datadoghq.com/logs?cols=%40latency%2Chost%2C%40body.error.message%2C%40data.message.metadata.status%2C%40body.amount&event&from_ts=1609182920697&index=&live=false&messageDisplay=inline&query=trace_id%3A3250228666586175386&stream_sort=desc&to_ts=1609184920724)

### Correção

A ideia é permitir que esses parâmetros desconhecidos sejam passados na request adicionando a opção `allowUnknown` na função Joi.validate, dessa forma eles serão ignorados pois não são utilizados e a request seguirá o seu curso normal, pois ela não irá barrar na validação do Joi.

### Melhorias

Achamos conveniente adicionar um log nesse endpoint para facilitar o monitoramento de casos como este diretamente no superbowleto, pois essa situação só foi localizada analisando os logs do service pagarme-api.

Também tivemos a necessidade de adicionar um nock em um test para interceptar a request na url https://homolog.meiosdepagamentobradesco.com.br e simular o retorno de sucess, pois essa requisição não estava retornando e isso estava fazendo quebrar o test.