### PR TITLE
normalize-percentage: use parseInt to deal with certain cases

### DIFF
--- a/src/providers/bradesco/index.js
+++ b/src/providers/bradesco/index.js
@@ -64,6 +64,7 @@ const normalizePercentage = ifElse(
   pipe(
     percentage => Number(percentage).toFixed(5),
     multiply(100000),
+    parseInt,
     toString,
     percentage => percentage.padStart(8, '0')
   ),

--- a/test/unit/providers/bradesco/index.js
+++ b/test/unit/providers/bradesco/index.js
@@ -215,6 +215,12 @@ test('normalizePercentage: with a float number', (t) => {
   t.is(normalizedPercentage, '09999000')
 })
 
+test('normalizePercentage: with a tricky float number', (t) => {
+  const normalizedPercentage = normalizePercentage('0.07')
+
+  t.is(normalizedPercentage, '00007000')
+})
+
 test('normalizePercentage: with a float number and 6 digits of precision', (t) => {
   const normalizedPercentage = normalizePercentage('99.999999')
 


### PR DESCRIPTION
Conforme relatado em thread do Slack interno, estávamos tendo alguns problemas na função `normalizePercentage`, quando chegavam alguns valores "peculiares".

Exemplo, se chegasse o valor `0.07` pra função, o retorno da mesma seria `7000.000000000001`. Com o uso do `parseInt` na cadeia de `pipe`, temos como retorno `00007000`, o valor esperado. 