### PR TITLE
boleto-api-caixa: enviar barcode e digitable line para o gateway

### DIFF
--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -132,9 +132,19 @@ const translateResponseCode = (axiosResponse) => {
 
   if (!hasErrors) {
     const boletoUrl = getBoletoUrl(axiosResponseData)
+    const digitableLine = path(['digitableLine'], axiosResponseData)
+    const barcode = path(['barCodeNumber'], axiosResponseData)
 
     if (!boletoUrl) {
       throw new Error('URL do boleto não existe')
+    }
+
+    if (!digitableLine) {
+      throw new Error('linha digitável do boleto não existe')
+    }
+
+    if (!barcode) {
+      throw new Error('código de barras do boleto não existe')
     }
 
     const defaultSuccessValue = {
@@ -142,6 +152,8 @@ const translateResponseCode = (axiosResponse) => {
       status: 'registered',
       issuer_response_code: '0',
       boleto_url: boletoUrl,
+      digitable_line: digitableLine,
+      barcode,
     }
 
     return defaultSuccessValue

--- a/test/integration/boleto/create/boleto-api-caixa/registered.js
+++ b/test/integration/boleto/create/boleto-api-caixa/registered.js
@@ -25,6 +25,8 @@ test.before(async () => {
         status: 'registered',
         issuer_response_code: '0',
         boleto_url: 'boletocaixa.com',
+        digitable_line: '1234.5678',
+        barcode: '123',
       })
     },
   }))
@@ -74,5 +76,7 @@ test('creates a boleto (status success)', async (t) => {
     company_document_number: payload.company_document_number,
     queue_url: payload.queue_url,
     boleto_url: 'boletocaixa.com',
+    digitable_line: '1234.5678',
+    barcode: '123',
   })
 })

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -156,6 +156,8 @@ test('translateResponseCode: with a "registered" code', (t) => {
 
   t.is(response.status, 'registered')
   t.is(response.boleto_url, 'https://blablahtml.com')
+  t.is(response.digitable_line, '98139178390283012831893193103293')
+  t.is(response.barcode, '804284028402804820482')
 })
 
 test('translateResponseCode: registered with empty errors', (t) => {
@@ -182,6 +184,8 @@ test('translateResponseCode: registered with empty errors', (t) => {
 
   t.is(response.status, 'registered')
   t.is(response.boleto_url, 'https://blablahtml.com')
+  t.is(response.digitable_line, '98139178390283012831893193103293')
+  t.is(response.barcode, '804284028402804820482')
 })
 
 test('translateResponseCode: with a "refused" code', (t) => {
@@ -249,6 +253,48 @@ test('translateResponseCode: with response missing html link', (t) => {
   })
 
   t.is(error.message, 'URL do boleto não existe')
+})
+
+test('translateResponseCode: with response missing digitable line', (t) => {
+  const axiosResponse = {
+    data: {
+      id: '37279202382',
+      barCodeNumber: '804284028402804820482',
+      links: [
+        {
+          href: 'https://blablahtml.com',
+          rel: 'html',
+          method: 'GET',
+        }],
+    },
+  }
+
+  const error = t.throws(() => {
+    translateResponseCode(axiosResponse)
+  })
+
+  t.is(error.message, 'linha digitável do boleto não existe')
+})
+
+test('translateResponseCode: with response missing barcode', (t) => {
+  const axiosResponse = {
+    data: {
+      id: '37279202382',
+      digitableLine: '98139178390283012831893193103293',
+      links: [
+        {
+          href: 'https://blablahtml.com',
+          rel: 'html',
+          method: 'GET',
+        }],
+    },
+  }
+
+  const error = t.throws(() => {
+    translateResponseCode(axiosResponse)
+  })
+
+  t.is(error.message, 'código de barras do boleto não existe')
 })
 
 test('buildHeaders', (t) => {


### PR DESCRIPTION
Atualmente ainda estamos usando o node-boleto para criar a linha digitável dos boletos da caixa, mas isso está errado, pois o node-boleto não sabe lidar com essa informação para o banco caixa. Então devemos recuperar essa informação da resposta da boleto-api e enviar corretamente para o gateway para que fique tudo certo no banco de dados do Core.

relates to  https://mundipagg.atlassian.net/browse/PGHOST-143