### PR TITLE
boleto-caixa: includes pagarme in recipient name

### DIFF
--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -60,7 +60,7 @@ const buildPayload = (boleto, operationId) => {
       documentNumber: String(path(['title_id'], boleto)),
     },
     recipient: {
-      name: path(['company_name'], boleto),
+      name: `${path(['company_name'], boleto)} | Pagar.me Pagamentos S/A`,
       document: {
         type: recipientDocumentType,
         number: path(['company_document_number'], boleto),

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -44,7 +44,7 @@ test('buildPayload with full payer_address', async (t) => {
       documentNumber: String(boleto.title_id),
     },
     recipient: {
-      name: boleto.company_name,
+      name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
       document: {
         type: getDocumentType(boleto.company_document_number),
         number: boleto.company_document_number,
@@ -98,7 +98,7 @@ test('buildPayload with payer_address incomplete', async (t) => {
       documentNumber: String(boleto.title_id),
     },
     recipient: {
-      name: boleto.company_name,
+      name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
       document: {
         type: getDocumentType(boleto.company_document_number),
         number: boleto.company_document_number,


### PR DESCRIPTION
Assim como nos boletos renderizados do Bradesco o nome do beneficiário aparece : "nome da company | Pagar.me Pagamentos S/A", precisamos que o mesmo aconteça nos boletos da Caixa.
Como, no caso da Caixa, usamos a renderização que o próprio banco retorna, é necessário incluir a parte da pagarme na request que enviamos para a boleto-api e caixa, assim o boleto renderizado terá todas as informações para o campo de beneficiário.

relates to https://mundipagg.atlassian.net/browse/PGHOST-160