### PR TITLE
boleto-api-caixa: add the correct agency to payload

### DIFF
--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -45,12 +45,13 @@ const buildPayload = (boleto, operationId) => {
   const formattedBuyerStateCode = formatStateCode(boleto, 'payer_address')
 
   const agreementNumber = 1103388
+  const agency = '3337'
 
   const payload = {
     bankNumber: caixaBankCode,
     agreement: {
       agreementNumber,
-      agency: path(['issuer_agency'], boleto),
+      agency,
     },
     title: {
       expireDate: formattedExpirationDate,

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -34,7 +34,7 @@ test('buildPayload with full payer_address', async (t) => {
     bankNumber: 104,
     agreement: {
       agreementNumber: 1103388,
-      agency: boleto.issuer_agency,
+      agency: '3337',
     },
     title: {
       expireDate: moment(boleto.expiration_date).tz('America/Sao_Paulo').format('YYYY-MM-DD'),
@@ -88,7 +88,7 @@ test('buildPayload with payer_address incomplete', async (t) => {
     bankNumber: 104,
     agreement: {
       agreementNumber: 1103388,
-      agency: boleto.issuer_agency,
+      agency: '3337',
     },
     title: {
       expireDate: moment(boleto.expiration_date).tz('America/Sao_Paulo').format('YYYY-MM-DD'),


### PR DESCRIPTION
Adiciona os dados corretos da agência para registro na Caixa, para corrigir, uma vez que as requests chegam com os dados do bradesco que estão chumbados no gateway. 