### PR TITLE
boleto-api-caixa: add pagarme cnpj

### DIFF
--- a/src/providers/boleto-api-caixa/formatter.js
+++ b/src/providers/boleto-api-caixa/formatter.js
@@ -11,16 +11,6 @@ const brazilianStates = require('../../lib/helpers/brazilian-states')
 
 const formatDate = timestamp => moment(timestamp).format('YYYY-MM-DD')
 
-const getDocumentType = (documentNumber) => {
-  const documentLength = String(documentNumber).trim().length
-
-  if (documentLength === 11) {
-    return 'CPF'
-  }
-
-  return 'CNPJ'
-}
-
 const formatStateCode = (boleto, from) => {
   const possibilities = ['payer_address', 'company_address']
 
@@ -42,5 +32,4 @@ const formatStateCode = (boleto, from) => {
 module.exports = {
   formatDate,
   formatStateCode,
-  getDocumentType,
 }

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -14,7 +14,6 @@ const { makeFromLogger } = require('../../lib/logger')
 const { isA4XXError } = require('../../lib/helpers/errors')
 const {
   formatDate,
-  getDocumentType,
   formatStateCode,
 } = require('./formatter')
 
@@ -40,12 +39,13 @@ const buildHeaders = () => {
 
 const buildPayload = (boleto, operationId) => {
   const formattedExpirationDate = formatDate(boleto.expiration_date)
-  const recipientDocumentType = getDocumentType(path(['company_document_number'], boleto))
   const formattedRecipientStateCode = formatStateCode(boleto, 'company_address')
   const formattedBuyerStateCode = formatStateCode(boleto, 'payer_address')
 
   const agreementNumber = 1103388
   const agency = '3337'
+  const recipientDocumentNumber = '18727053000174'
+  const recipientDocumentType = 'CNPJ'
 
   const payload = {
     bankNumber: caixaBankCode,
@@ -64,7 +64,7 @@ const buildPayload = (boleto, operationId) => {
       name: `${path(['company_name'], boleto)} | Pagar.me Pagamentos S/A`,
       document: {
         type: recipientDocumentType,
-        number: path(['company_document_number'], boleto),
+        number: recipientDocumentNumber,
       },
       address: {
         street: path(['company_address', 'street'], boleto),

--- a/test/unit/providers/boleto-api-caixa/formatter.js
+++ b/test/unit/providers/boleto-api-caixa/formatter.js
@@ -1,43 +1,7 @@
 import test from 'ava'
 import {
-  getDocumentType,
   formatStateCode,
 } from '../../../../src/providers/boleto-api-caixa/formatter'
-
-test('getDocumentType: when document is CPF', (t) => {
-  const documentNumber = '01234567890'
-  const result = getDocumentType(documentNumber)
-
-  t.is(result, 'CPF')
-})
-
-test('getDocumentType: when document is CNPJ', (t) => {
-  const documentNumber = '01234567890123'
-  const result = getDocumentType(documentNumber)
-
-  t.is(result, 'CNPJ')
-})
-
-test('getDocumentType: when document is wrong, return default', (t) => {
-  const documentNumber = '1'
-  const result = getDocumentType(documentNumber)
-
-  t.is(result, 'CNPJ')
-})
-
-test('getDocumentType: when document is CPF and has spaces', (t) => {
-  const documentNumber = '    01234567890 '
-  const result = getDocumentType(documentNumber)
-
-  t.is(result, 'CPF')
-})
-
-test('getDocumentType: when document is CNPJ and has spaces', (t) => {
-  const documentNumber = '    01234567890123 '
-  const result = getDocumentType(documentNumber)
-
-  t.is(result, 'CNPJ')
-})
 
 test('formatStateCode: finding state on list for payer_address', (t) => {
   const boleto = {

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -9,9 +9,6 @@ import {
   isHtml,
   getBoletoUrl,
 } from '../../../../src/providers/boleto-api-caixa'
-import {
-  getDocumentType,
-} from '../../../../src/providers/boleto-api-caixa/formatter'
 
 test('buildPayload with full payer_address', async (t) => {
   const boleto = await createBoleto({
@@ -46,8 +43,8 @@ test('buildPayload with full payer_address', async (t) => {
     recipient: {
       name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
       document: {
-        type: getDocumentType(boleto.company_document_number),
-        number: boleto.company_document_number,
+        type: 'CNPJ',
+        number: '18727053000174',
       },
       address: {
         street: boleto.company_address.street,
@@ -100,8 +97,8 @@ test('buildPayload with payer_address incomplete', async (t) => {
     recipient: {
       name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
       document: {
-        type: getDocumentType(boleto.company_document_number),
-        number: boleto.company_document_number,
+        type: 'CNPJ',
+        number: '18727053000174',
       },
       address: {
         street: boleto.company_address.street,


### PR DESCRIPTION
Ao tentar registrar boletos de outras companies na Caixa, descobrimos que a Caixa utiliza apenas os dados do beneficiário(Pagar.me) para o registro dos boletos e não possui o campo sacador avalista(company), então precisamos manter fixo o cnpj da pagarme para o registro ocorrer com sucesso.