### PR TITLE
boleto-api-caixa : envia boleto rules para boleto-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
-version: 2
+version: 2.1
+
+parameters:
+  machine_image:
+    type: string
+    default: "ubuntu-2004:202010-01" 
 
 _run:
   prepare_to_deploy: &prepare_to_deploy
@@ -8,7 +13,8 @@ _run:
       # install jq
       curl -sSL -o ~/.local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x ~/.local/bin/jq
       # install ecs-deploy (in work version)
-      curl -sSL -o /tmp/ecs-deploy.tar.gz https://github.com/silinternational/ecs-deploy/archive/3.4.0.tar.gz && tar xvfz /tmp/ecs-deploy.tar.gz -C /tmp && sudo cp /tmp/ecs-deploy-3.4.0/ecs-deploy ~/.local/bin/ecs-deploy
+      curl -sSL -o /tmp/ecs-deploy.tar.gz https://github.com/silinternational/ecs-deploy/archive/3.10.0.tar.gz && tar xvfz /tmp/ecs-deploy.tar.gz -C /tmp && sudo cp /tmp/ecs-deploy-3.10.0/ecs-deploy ~/.local/bin/ecs-deploy
+      pip install --upgrade "pip>=9.0,<=20.3.4"
       pip install awscli --upgrade --user
   pull_sonar_image: &pull_sonar_image
     name: Pull Docker sonar-scanner image
@@ -18,7 +24,8 @@ _run:
 
 jobs:
   test:
-    machine: true
+    machine:
+      image: << pipeline.parameters.machine_image >>
     steps:
       - attach_workspace:
           at: ~/project
@@ -47,7 +54,8 @@ jobs:
           paths:
             - ./
   sonar:
-    machine: true
+    machine:
+      image: << pipeline.parameters.machine_image >>
     steps:
       - attach_workspace:
           at: ~/project
@@ -58,7 +66,7 @@ jobs:
   build_image:
     working_directory: ~/superbowleto
     machine:
-        enabled: true
+      image: << pipeline.parameters.machine_image >>
     steps:
       - checkout
       - run:
@@ -75,7 +83,7 @@ jobs:
   push_stg:
     working_directory: ~/superbowleto
     machine:
-        enabled: true
+      image: << pipeline.parameters.machine_image >>
     steps:
       - attach_workspace:
          at: ~/superbowleto/images
@@ -86,8 +94,9 @@ jobs:
             export AWS_ACCESS_KEY_ID=$STG_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$STG_AWS_SECRET_ACCESS_KEY
             export AWS_ACCOUNT=$STG_AWS_ACCOUNT
+            export AWS_REGION=$REGION
             #ecr-login
-            eval $(aws ecr get-login --region us-east-1 --no-include-email)
+            aws ecr get-login-password | docker login --username AWS --password-stdin "$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-stg"
             # build and push server
             export STG_IMAGE="$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-stg"
             docker tag build:latest ${STG_IMAGE}:$CIRCLE_TAG
@@ -97,7 +106,7 @@ jobs:
   push_sdx:
     working_directory: ~/superbowleto
     machine:
-        enabled: true
+      image: << pipeline.parameters.machine_image >>
     steps:
       - attach_workspace:
          at: ~/superbowleto/images
@@ -108,8 +117,9 @@ jobs:
             export AWS_ACCESS_KEY_ID=$SDX_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$SDX_AWS_SECRET_ACCESS_KEY
             export AWS_ACCOUNT=$SDX_AWS_ACCOUNT
+            export AWS_REGION=$REGION
             #ecr-login
-            eval $(aws ecr get-login --region us-east-1 --no-include-email)
+            aws ecr get-login-password | docker login --username AWS --password-stdin "$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-sdx"
             # build and push server
             export SDX_IMAGE="$SDX_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-sdx"
             docker tag build:latest ${SDX_IMAGE}:$CIRCLE_TAG
@@ -119,7 +129,7 @@ jobs:
   push_prd:
     working_directory: ~/superbowleto
     machine:
-        enabled: true
+      image: << pipeline.parameters.machine_image >>
     steps:
       - attach_workspace:
           at: ~/superbowleto/images
@@ -130,8 +140,9 @@ jobs:
             export AWS_ACCESS_KEY_ID=$PRD_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$PRD_AWS_SECRET_ACCESS_KEY
             export AWS_ACCOUNT=$PRD_AWS_ACCOUNT
+            export AWS_REGION=$REGION
             #ecr-login
-            eval $(aws ecr get-login --region us-east-1 --no-include-email)
+            aws ecr get-login-password | docker login --username AWS --password-stdin "$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-prd"
             # build and push server
             export PRD_IMAGE="$PRD_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-prd"
             docker tag build:latest ${PRD_IMAGE}:$CIRCLE_TAG
@@ -140,7 +151,8 @@ jobs:
             docker push ${PRD_IMAGE}:latest
   deploy_stg:
     working_directory: ~/superbowleto
-    machine: true
+    machine:
+      image: << pipeline.parameters.machine_image >>
     steps:
       - run: *prepare_to_deploy
       - checkout
@@ -157,7 +169,8 @@ jobs:
             ~/.local/bin/ecs-deploy --max-definitions 1 --enable-rollback -c $STG_CLUSTER -r $REGION -n superbowleto-w-stg -i $STG_IMAGE --timeout $TIMEOUT
   deploy_sdx:
     working_directory: ~/superbowleto
-    machine: true
+    machine:
+      image: << pipeline.parameters.machine_image >>
     steps:
       - run: *prepare_to_deploy
       - checkout
@@ -174,7 +187,8 @@ jobs:
             ~/.local/bin/ecs-deploy --max-definitions 2 --enable-rollback -c $SDX_CLUSTER -r $REGION -n superbowleto-w-sdx -i $SDX_IMAGE --timeout $TIMEOUT
   deploy_prd:
     working_directory: ~/superbowleto
-    machine: true
+    machine:
+      image: << pipeline.parameters.machine_image >>
     steps:
       - run: *prepare_to_deploy
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             export AWS_ACCOUNT=$SDX_AWS_ACCOUNT
             export AWS_REGION=$REGION
             #ecr-login
-            aws ecr get-login-password | docker login --username AWS --password-stdin "$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-sdx"
+            aws ecr get-login-password | docker login --username AWS --password-stdin "$SDX_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-sdx"
             # build and push server
             export SDX_IMAGE="$SDX_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-sdx"
             docker tag build:latest ${SDX_IMAGE}:$CIRCLE_TAG
@@ -142,7 +142,7 @@ jobs:
             export AWS_ACCOUNT=$PRD_AWS_ACCOUNT
             export AWS_REGION=$REGION
             #ecr-login
-            aws ecr get-login-password | docker login --username AWS --password-stdin "$STG_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-prd"
+            aws ecr get-login-password | docker login --username AWS --password-stdin "$PRD_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-prd"
             # build and push server
             export PRD_IMAGE="$PRD_AWS_ACCOUNT.dkr.ecr.$REGION.amazonaws.com/superbowleto-prd"
             docker tag build:latest ${PRD_IMAGE}:$CIRCLE_TAG

--- a/src/lib/helpers/configurations.js
+++ b/src/lib/helpers/configurations.js
@@ -67,10 +67,24 @@ const findBoletoConfiguration = async (boleto, operationId) => {
 }
 
 const setBoletoRulesConfiguration = (boleto, operationId) => {
-  const config = {
+  let config
+
+  const configBradesco = {
     issuer: 'bradesco',
     issuer_account: '469',
     issuer_agency: '1229',
+  }
+
+  const configCaixa = {
+    issuer: 'boleto-api-caixa',
+    issuer_account: '1103388',
+    issuer_agency: '3337',
+  }
+
+  if (boleto.issuer === 'boleto-api-caixa') {
+    config = configCaixa
+  } else {
+    config = configBradesco
   }
 
   if (boleto.rules && boleto.issuer !== 'development') {

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -37,6 +37,37 @@ const buildHeaders = () => {
   }
 }
 
+const noStrictRules = {
+  acceptDivergentAmount: true,
+  maxDaysToPayPastDue: 60,
+}
+
+const strictExpirateDateRules = {
+  acceptDivergentAmount: false,
+  maxDaysToPayPastDue: 0,
+}
+
+const defineRules = (boleto) => {
+  if (boleto.rules) {
+    if (boleto.rules.includes('strict_expiration_date')) {
+      return strictExpirateDateRules
+    }
+    if (boleto.rules.includes('no_strict')) {
+      return noStrictRules
+    }
+  }
+
+  if (boleto.issuer_wallet === '25') {
+    return strictExpirateDateRules
+  }
+
+  if (boleto.issuer_wallet === '26') {
+    return noStrictRules
+  }
+
+  return null
+}
+
 const buildPayload = (boleto, operationId) => {
   const formattedExpirationDate = formatDate(boleto.expiration_date)
   const formattedRecipientStateCode = formatStateCode(boleto, 'company_address')
@@ -59,6 +90,7 @@ const buildPayload = (boleto, operationId) => {
       ourNumber: path(['title_id'], boleto),
       instructions: path(['instructions'], boleto),
       documentNumber: String(path(['title_id'], boleto)),
+      rules: defineRules(boleto),
     },
     recipient: {
       name: `${path(['company_name'], boleto)} | Pagar.me Pagamentos S/A`,

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -44,7 +44,7 @@ const noStrictRules = {
 
 const strictExpirateDateRules = {
   acceptDivergentAmount: false,
-  maxDaysToPayPastDue: 0,
+  maxDaysToPayPastDue: 1,
 }
 
 const defineRules = (boleto) => {

--- a/test/unit/lib/helper/configurations.js
+++ b/test/unit/lib/helper/configurations.js
@@ -97,3 +97,29 @@ test('setBoletoRulesConfiguration: strict_expiration_date', async (t) => {
     company_name: payload.company_name,
   })
 })
+
+test('setBoletoRulesConfiguration: caixa with no_strict rules', async (t) => {
+  const payload = mock
+  const operationId = cuid()
+
+  payload.rules = ['no_strict']
+  payload.issuer = 'boleto-api-caixa'
+
+
+  const boleto = await setBoletoRulesConfiguration(payload, operationId)
+
+  t.is(boleto.issuer_wallet, '26')
+  t.is(boleto.issuer, 'boleto-api-caixa')
+
+  assert.containSubset(boleto, {
+    issuer: boleto.issuer,
+    issuer_account: boleto.issuer_account,
+    issuer_agency: boleto.issuer_agency,
+    issuer_wallet: boleto.issuer_wallet,
+    amount: payload.amount,
+    instructions: payload.instructions,
+    payer_name: payload.payer_name,
+    company_name: payload.company_name,
+  })
+})
+

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -17,7 +17,7 @@ const noStrictRules = {
 
 const strictExpirateDateRules = {
   acceptDivergentAmount: false,
-  maxDaysToPayPastDue: 0,
+  maxDaysToPayPastDue: 1,
 }
 
 test('buildPayload without rules and wallet then title.rules should be null', async (t) => {

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -10,7 +10,71 @@ import {
   getBoletoUrl,
 } from '../../../../src/providers/boleto-api-caixa'
 
+const noStrictRules = {
+  acceptDivergentAmount: true,
+  maxDaysToPayPastDue: 60,
+}
+
+const strictExpirateDateRules = {
+  acceptDivergentAmount: false,
+  maxDaysToPayPastDue: 0,
+}
+
+test('buildPayload without rules and wallet then title.rules should be null', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto()
+  delete boleto.issuer_wallet
+
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.title.rules, null)
+})
+
+test('buildPayload with no_strict rules then title.rules should have no_strict rules', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    rules: ['no_strict'],
+  })
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.title.rules, noStrictRules)
+})
+
+test('buildPayload with strict_expiration_date rules then title.rules should have strict_expiration_date rules', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    rules: ['strict_expiration_date'],
+  })
+
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.title.rules, strictExpirateDateRules)
+})
+
+test('buildPayload without rules and wallet 25 then title.rules should have strict_expiration_date rules', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    issuer_wallet: '25',
+  })
+
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.title.rules, strictExpirateDateRules)
+})
+
+test('buildPayload without rules and wallet 26 then title.rules should have no_strict rules', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    issuer_wallet: '26',
+  })
+
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.title.rules, noStrictRules)
+})
+
 test('buildPayload with full payer_address', async (t) => {
+  const operationId = cuid()
   const boleto = await createBoleto({
     payer_address: {
       zipcode: '5555555',
@@ -23,60 +87,36 @@ test('buildPayload with full payer_address', async (t) => {
     },
   })
 
-  const operationId = cuid()
-
   const payload = buildPayload(boleto, operationId)
 
-  t.deepEqual(payload, {
-    bankNumber: 104,
-    agreement: {
-      agreementNumber: 1103388,
-      agency: '3337',
-    },
-    title: {
-      expireDate: moment(boleto.expiration_date).tz('America/Sao_Paulo').format('YYYY-MM-DD'),
-      amountInCents: boleto.amount,
-      ourNumber: boleto.title_id,
-      instructions: boleto.instructions,
-      documentNumber: String(boleto.title_id),
-    },
-    recipient: {
-      name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
-      document: {
-        type: 'CNPJ',
-        number: '18727053000174',
-      },
-      address: {
-        street: boleto.company_address.street,
-        number: boleto.company_address.street_number,
-        complement: boleto.company_address.complementary,
-        zipCode: boleto.company_address.zipcode,
-        district: boleto.company_address.neighborhood,
-        city: boleto.company_address.city,
-        stateCode: boleto.company_address.state,
-      },
-    },
-    buyer: {
-      name: boleto.payer_name,
-      document: {
-        type: boleto.payer_document_type.toUpperCase(),
-        number: boleto.payer_document_number,
-      },
-      address: {
-        street: boleto.payer_address.street,
-        number: boleto.payer_address.street_number,
-        complement: boleto.payer_address.complementary,
-        district: boleto.payer_address.neighborhood,
-        zipCode: boleto.payer_address.zipcode,
-        city: boleto.payer_address.city,
-        stateCode: boleto.payer_address.state,
-      },
-    },
-    requestKey: operationId,
+  t.deepEqual(payload.buyer.address, {
+    street: boleto.payer_address.street,
+    number: boleto.payer_address.street_number,
+    complement: boleto.payer_address.complementary,
+    district: boleto.payer_address.neighborhood,
+    zipCode: boleto.payer_address.zipcode,
+    city: boleto.payer_address.city,
+    stateCode: boleto.payer_address.state,
   })
 })
 
 test('buildPayload with payer_address incomplete', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto()
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.buyer.address, {
+    street: 'Rua Fidêncio Ramos',
+    number: '308',
+    complement: '9º andar, conjunto 91',
+    zipCode: '04551010',
+    district: 'Vila Olímpia',
+    city: 'São Paulo',
+    stateCode: 'SP',
+  })
+})
+
+test('buildPayload complete', async (t) => {
   const operationId = cuid()
   const boleto = await createBoleto()
   const payload = buildPayload(boleto, operationId)
@@ -93,6 +133,10 @@ test('buildPayload with payer_address incomplete', async (t) => {
       ourNumber: boleto.title_id,
       instructions: boleto.instructions,
       documentNumber: String(boleto.title_id),
+      rules: {
+        acceptDivergentAmount: true,
+        maxDaysToPayPastDue: 60,
+      },
     },
     recipient: {
       name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
@@ -129,6 +173,7 @@ test('buildPayload with payer_address incomplete', async (t) => {
     requestKey: operationId,
   })
 })
+
 
 test('translateResponseCode: with a "registered" code', (t) => {
   const axiosResponse = {


### PR DESCRIPTION
Esta modificação tem por objetivo remover a funcionalidade que força a virada para emissor Bradesco caso o cliente envie o nó `boleto_rules` ou se o mesmo tiver configurado na company a `issuer_wallet = 26`. A virada para o Bradesco era necessária porque a BoletoAPI não aceitava regras menos restritivas de pagamento (baixa em D+n e pagamento divergente do valor do título). Com a implementação da v2 na BoletoAPI, a mesma passará a receber tais informações e a virada para o Bradesco deixará de ser obrigatória. Evidências dos testes no card da tarefa.

relates to : [BPROC-98](https://mundipagg.atlassian.net/browse/BPROC-98)