### PR TITLE
Correct the documentation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The following steps illustrate the case where the provider **could** be reached 
 
 ##### b) Provider **could not** process the boleto
 
-The following steps illustrate the case where the provider **could** be reached and it could process the boleto.
+The following steps illustrate the case where the provider **could not** be reached or it **could not** process the boleto.
 
 1. The `Client` makes an HTTP request to create a boleto.
 1. We create the boleto in the `Database` with status `issued`.


### PR DESCRIPTION
## Description

On the documentation, at data flow there are two cases of what can happen after creating a boleto. The case b is the case wich the provider could not be reached, but the description is saying the opposite of it. The description is now correct.

- Why is the PR needed
  - To correct documentation
- What the PR does
  - Correct the documentation description for provider could not be reached
