### PR TITLE
Makefile documentation structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,71 @@
-console:
+# This will output the help for each task.
+# Thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.DEFAULT_GOAL := help
+help: ## Show helpful information concerning the available tasks
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+.PHONY: help
+
+console: ## Run all tests, with shell as the interactive console
 	@docker-compose run test /bin/sh
 .PHONY: console
 
-rebuild:
+rebuild: ## Build the test service
 	@docker-compose build test
 .PHONY: rebuild
 
-teardown:
+teardown: ## Stop and remove local containers
 	@docker-compose down -v --rmi local
 .PHONY: teardown
 
-lint:
+lint: ## Run the JavaScript code linting tool
 	@docker-compose run lint
 .PHONY: lint
 
-test-ci: start-yopa migrate
+test-ci: start-yopa migrate ## Generate coverage report and xml test results report to be published at the CircleCI
 	@docker-compose run --entrypoint="npm run test-ci" test --abort-on-container-exit
 .PHONY: test-ci
 
-test: start-yopa migrate
+test: start-yopa migrate ## Run all tests
 	@docker-compose up --abort-on-container-exit test
 .PHONY: test
 
-test-functional:
+test-functional: ## Run only functional tests
 	@docker-compose run test-functional
 .PHONY: test-functional
 
-test-integration:
+test-integration: ## Run only integration tests
 	@docker-compose run test-integration
 .PHONY: test-integration
 
-test-unit:
+test-unit: ## Run only unit tests
 	@docker-compose run test-unit
 .PHONY: test-unit
 
-start-db:
+start-db: ## Start database (postgres)
 	@docker-compose up -d postgres
 .PHONY: start-db
 
-migrate:
+migrate: ## Run the migrations
 	@docker-compose up migrate
 .PHONY: migrate
 
-setup-db: start-db migrate
+setup-db: ## Start database and run migrations in one command
+	start-db migrate
 .PHONY: setup-db
 
-start-yopa:
+start-yopa: ## Start the Yopa service, in detached mode
 	@docker-compose up -d yopa
 .PHONY: start-yopa
 
-superbowleto-web:
+superbowleto-web: ## Run the application server
 	@docker-compose up superbowleto-web
 .PHONY: superbowleto-web
 
-superbowleto-worker:
+superbowleto-worker: ## Start the boleto queue processing worker
 	@docker-compose up superbowleto-worker
 .PHONY: superbowleto-worker
 
-sonar:
+sonar: ## Run the Sonar Scanner tool for the current branch
 	sed -i 's/\/superbowleto\/src\//src\//g' coverage/lcov.info
 	@docker run -ti -v $(shell pwd):/usr/src pagarme/sonar-scanner -Dsonar.branch.name=${BRANCH}
 .PHONY: sonar

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 - [Technology](#technology)
 - [Developing](#developing)
-	- [First Install](#first-install)
-	- [Running tests](#running-tests)
-	- [Installing new dependencies](#installing-new-dependencies)
+  - [Makefile](#makefile)
+  - [First Install](#first-install)
+  - [Running tests](#running-tests)
+  - [Note concerning Makefile](#note-concerning-makefile)
 - [Testing](#testing)
 - [Data Flow](#data-flow)
 	- [Server](#server)
@@ -38,6 +39,18 @@ Here's a brief overview of our technology stack:
 
 In order to develop for this project you must have [Docker](https://docs.docker.com/)
 and [Docker Compose](https://docs.docker.com/compose/) installed.
+
+### Makefile
+
+In order to obtain information about various commands that the `make` tool supports in this project, just run:
+
+```sh
+$ make
+```
+or
+```sh
+$ make help
+```
 
 ### First Install
 
@@ -102,7 +115,7 @@ Tests are separate in `functional`, `integration` and `unit`. You can either run
   $ docker-compose run test npm run test-unit
   ```
 
-For the CI purposes we have a specif command that will generate coverage report and xml test results report to be published at the CircleCI.
+For the CI purposes we have a specific command that will generate coverage report and xml test results report to be published at the CircleCI.
 
   ```sh
   $ docker-compose run --entrypoint="npm run test-ci" test --abort-on-container-exit


### PR DESCRIPTION
## Description

This pull request implements a documentation structure for the project's Makefile, based on this [article](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html). This structure is meant to be interactive via terminal and can be easily updated, even for lengthy Makefiles.

### Why is the PR needed?
To facilitate the life of the developers, in the search for useful information concerning project manipulation.

### What the PR does?
Implements a `help` task in the Makefile:
```Makefile
.DEFAULT_GOAL := help
help: ## Show helpful information concerning the available tasks
	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
.PHONY: help
```
that performs the parsing, via a regular expression, of the comments denoting the help information, starting with `##`, that must be written in the same line of the task declaration, eg.:
```Makefile
fizz-buzz: ## This is the docstring. This task just prints "Fizz Buzz"
         @echo 'Fizz Buzz'
.PHONY: fizz-buzz
```

## What are possible side effects?
If the docstring is not specified under the established format, some scripts may stop working.

## Checklist

- [ ] At the project's root, run in the terminal `make` or `make help`. Either one should list the tasks and their respective docstrings, as illustrated below:
![make-help-demo](https://user-images.githubusercontent.com/35070513/156945106-5e37267f-e50f-4247-b91e-0f3b308b3231.gif)
- [ ] Run each task separately, to make sure that their execution was not impaired by the introduction of the docstring.
