### PR TITLE
[BPROC-402] - Adição de campo sacador avalista no request da caixa da superbowleto para a boleto-api

### DIFF
--- a/src/providers/boleto-api-caixa/formatter.js
+++ b/src/providers/boleto-api-caixa/formatter.js
@@ -29,7 +29,19 @@ const formatStateCode = (boleto, from) => {
   return formatted(boleto)
 }
 
+const getDocumentType = (documentNumber) => {
+  if (!documentNumber) {
+    return ''
+  }
+  const documentLength = String(documentNumber).trim().length
+  if (documentLength === 11) {
+    return 'CPF'
+  }
+  return 'CNPJ'
+}
+
 module.exports = {
   formatDate,
   formatStateCode,
+  getDocumentType,
 }

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -3,11 +3,11 @@ const Promise = require('bluebird')
 const cuid = require('cuid')
 const {
   path,
+  pathOr,
   prop,
   find,
   propEq,
   pipe,
-  pathOr,
 } = require('ramda')
 
 const { encodeBase64 } = require('../../lib/encoding')
@@ -15,6 +15,7 @@ const { makeFromLogger } = require('../../lib/logger')
 const { isA4XXError } = require('../../lib/helpers/errors')
 const {
   formatDate,
+  getDocumentType,
   formatStateCode,
 } = require('./formatter')
 
@@ -31,6 +32,7 @@ const makeLogger = makeFromLogger('boleto-api-caixa/index')
 const caixaBankCode = 104
 const agreementNumber = 1103388
 const agency = '3337'
+const recipientName = 'Pagar.me Pagamentos S/A'
 const recipientDocumentNumber = '18727053000174'
 const recipientDocumentType = 'CNPJ'
 const defaultFeesAmountInCents = 0
@@ -126,10 +128,10 @@ const defineFees = (boleto) => {
   return null
 }
 
-const getInstructions = (companyName, boleto) => {
+const getInstructions = (companyName, companyDocument, boleto) => {
   let instructions = path(['instructions'], boleto) || ''
 
-  instructions += ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - CNPJ: ${recipientDocumentNumber}. Para confirmar a existência deste boleto consulte em pagar.me/boletos.`
+  instructions += ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - CNPJ: ${companyDocument}. Para confirmar a existência deste boleto consulte em pagar.me/boletos.`
 
   return instructions
 }
@@ -138,9 +140,10 @@ const buildPayload = (boleto, operationId) => {
   const formattedExpirationDate = formatDate(boleto.expiration_date)
   const formattedRecipientStateCode = formatStateCode(boleto, 'company_address')
   const formattedBuyerStateCode = formatStateCode(boleto, 'payer_address')
-  const companyName = path(['company_name'], boleto)
+  const companyName = pathOr('', ['company_name'], boleto)
+  const companyDocument = pathOr('', ['company_document_number'], boleto)
 
-  const instructions = getInstructions(companyName, boleto)
+  const instructions = getInstructions(companyName, companyDocument, boleto)
 
   const payload = {
     bankNumber: caixaBankCode,
@@ -158,33 +161,40 @@ const buildPayload = (boleto, operationId) => {
       fees: defineFees(boleto),
     },
     recipient: {
-      name: `${companyName} | Pagar.me Pagamentos S/A`,
+      name: recipientName,
       document: {
         type: recipientDocumentType,
-        number: recipientDocumentNumber,
+        number: String(recipientDocumentNumber),
       },
       address: {
         street: path(['company_address', 'street'], boleto),
-        number: path(['company_address', 'street_number'], boleto),
+        number: String(path(['company_address', 'street_number'], boleto)),
         complement: path(['company_address', 'complementary'], boleto),
-        zipCode: path(['company_address', 'zipcode'], boleto),
+        zipCode: String(path(['company_address', 'zipcode'], boleto)),
         district: path(['company_address', 'neighborhood'], boleto),
         city: path(['company_address', 'city'], boleto),
         stateCode: formattedRecipientStateCode,
       },
     },
+    payeeGuarantor: {
+      name: companyName,
+      document: {
+        type: getDocumentType(companyDocument),
+        number: String(companyDocument),
+      },
+    },
     buyer: {
       name: path(['payer_name'], boleto),
       document: {
-        number: path(['payer_document_number'], boleto),
+        number: String(path(['payer_document_number'], boleto)),
         type: path(['payer_document_type'], boleto).toUpperCase(),
       },
       address: {
         street: path(['payer_address', 'street'], boleto),
-        number: path(['payer_address', 'street_number'], boleto),
+        number: String(path(['payer_address', 'street_number'], boleto)),
         complement: path(['payer_address', 'complementary'], boleto),
         district: path(['payer_address', 'neighborhood'], boleto),
-        zipCode: path(['payer_address', 'zipcode'], boleto),
+        zipCode: String(path(['payer_address', 'zipcode'], boleto)),
         city: path(['payer_address', 'city'], boleto),
         stateCode: formattedBuyerStateCode,
       },

--- a/test/unit/providers/boleto-api-caixa/formatter.js
+++ b/test/unit/providers/boleto-api-caixa/formatter.js
@@ -1,7 +1,29 @@
 import test from 'ava'
 import {
   formatStateCode,
+  getDocumentType,
 } from '../../../../src/providers/boleto-api-caixa/formatter'
+
+test('getDocumentType: when document is CPF', (t) => {
+  const documentNumber = '01234567890'
+  const result = getDocumentType(documentNumber)
+
+  t.is(result, 'CPF')
+})
+
+test('getDocumentType: when document is CNPJ', (t) => {
+  const documentNumber = '99000467000107'
+  const result = getDocumentType(documentNumber)
+
+  t.is(result, 'CNPJ')
+})
+
+test('getDocumentType: when document is empty', (t) => {
+  const documentNumber = ''
+  const result = getDocumentType(documentNumber)
+
+  t.is(result, '')
+})
 
 test('formatStateCode: finding state on list for payer_address', (t) => {
   const boleto = {

--- a/test/unit/providers/boleto-api-caixa/index.js
+++ b/test/unit/providers/boleto-api-caixa/index.js
@@ -9,6 +9,10 @@ import {
   isHtml,
   getBoletoUrl,
 } from '../../../../src/providers/boleto-api-caixa'
+import {
+  getDocumentType,
+} from '../../../../src/providers/boleto-api-caixa/formatter'
+
 
 const noStrictRules = {
   acceptDivergentAmount: true,
@@ -20,7 +24,9 @@ const strictExpirateDateRules = {
   maxDaysToPayPastDue: 1,
 }
 
-const defaultInstruction = ' A emissão deste boleto foi solicitada e/ou intermediada pela empresa company name test - CNPJ: 18727053000174. Para confirmar a existência deste boleto consulte em pagar.me/boletos.'
+function getDefaultInstruction (companyName = 'company name test', companyDocumentNumber) {
+  return ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - CNPJ: ${companyDocumentNumber}. Para confirmar a existência deste boleto consulte em pagar.me/boletos.`
+}
 
 test('buildPayload without rules and wallet then title.rules should be null', async (t) => {
   const operationId = cuid()
@@ -124,7 +130,10 @@ test('buildPayload with the instruction field filled should return the received 
   const payload = buildPayload(boleto, operationId)
 
   let instructionsExpected = boleto.instructions
-  instructionsExpected += `${defaultInstruction}`
+  instructionsExpected += getDefaultInstruction(
+    boleto.companyName,
+    boleto.company_document_number
+  )
 
   t.deepEqual(payload.title.instructions, instructionsExpected)
 })
@@ -134,7 +143,10 @@ test('buildPayload with empty instruction field should return default instructio
   const boleto = await createBoleto({ instructions: '', company_name: 'company name test' })
   const payload = buildPayload(boleto, operationId)
 
-  t.deepEqual(payload.title.instructions, defaultInstruction)
+  t.deepEqual(payload.title.instructions, getDefaultInstruction(
+    boleto.companyName,
+    boleto.company_document_number
+  ))
 })
 
 test('buildPayload with null instruction field should return default instruction', async (t) => {
@@ -142,7 +154,10 @@ test('buildPayload with null instruction field should return default instruction
   const boleto = await createBoleto({ instructions: null, company_name: 'company name test' })
   const payload = buildPayload(boleto, operationId)
 
-  t.deepEqual(payload.title.instructions, defaultInstruction)
+  t.deepEqual(payload.title.instructions, getDefaultInstruction(
+    boleto.companyName,
+    boleto.company_document_number
+  ))
 })
 
 test('buildPayload with undefined instruction field should return default instruction', async (t) => {
@@ -150,7 +165,10 @@ test('buildPayload with undefined instruction field should return default instru
   const boleto = await createBoleto({ instructions: undefined, company_name: 'company name test' })
   const payload = buildPayload(boleto, operationId)
 
-  t.deepEqual(payload.title.instructions, defaultInstruction)
+  t.deepEqual(payload.title.instructions, getDefaultInstruction(
+    boleto.companyName,
+    boleto.company_document_number
+  ))
 })
 
 test('buildPayload with undefined fine should return the fine fields with default values in the payload correctly', async (t) => {
@@ -391,7 +409,10 @@ test('buildPayload complete', async (t) => {
   const payload = buildPayload(boleto, operationId)
 
   let { instructions } = boleto
-  instructions += `${defaultInstruction}`
+  instructions += getDefaultInstruction(
+    boleto.companyName,
+    boleto.company_document_number
+  )
 
   t.deepEqual(payload, {
     bankNumber: 104,
@@ -422,8 +443,15 @@ test('buildPayload complete', async (t) => {
         },
       },
     },
+    payeeGuarantor: {
+      name: boleto.company_name,
+      document: {
+        type: getDocumentType(boleto.company_document_number),
+        number: boleto.company_document_number,
+      },
+    },
     recipient: {
-      name: `${boleto.company_name} | Pagar.me Pagamentos S/A`,
+      name: 'Pagar.me Pagamentos S/A',
       document: {
         type: 'CNPJ',
         number: '18727053000174',
@@ -458,6 +486,56 @@ test('buildPayload complete', async (t) => {
   })
 })
 
+test('buildPayload with payeeGuarantor fields null', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    company_name: null,
+    company_document_number: null,
+  })
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.payeeGuarantor, {
+    name: '',
+    document: {
+      type: '',
+      number: '',
+    },
+  })
+})
+
+test('buildPayload with payeeGuarantor fields undefined', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    company_name: undefined,
+    company_document_number: undefined,
+  })
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.payeeGuarantor, {
+    name: '',
+    document: {
+      type: '',
+      number: '',
+    },
+  })
+})
+
+test('buildPayload with payeeGuarantor fields empty', async (t) => {
+  const operationId = cuid()
+  const boleto = await createBoleto({
+    company_name: '',
+    company_document_number: '',
+  })
+  const payload = buildPayload(boleto, operationId)
+
+  t.deepEqual(payload.payeeGuarantor, {
+    name: '',
+    document: {
+      type: '',
+      number: '',
+    },
+  })
+})
 
 test('translateResponseCode: with a "registered" code', (t) => {
   const axiosResponse = {


### PR DESCRIPTION
## Description

Após adição do campo sacador avalista no request da boleto-api, o campo do sacador avalista deve ser adicionado no request da superbowleto para a boleto-api. Este PR adiciona o campo sacador avalista (payeeGuarantor) no request da caixa.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
