### PR TITLE
[BPROC-390] - opens the Boleto Caixa lock with interest and fine for BoletoAPI

### DIFF
--- a/src/lib/helpers/providers.js
+++ b/src/lib/helpers/providers.js
@@ -15,15 +15,12 @@ const changeIssuerWhenInterestOrFine = (boleto, operationId) => {
     fine,
     interest,
     issuer,
-    external_id: externalId,
   } = boleto
 
-  const companyCaixaFineAndInterestTestId = '5aba73e21b9d0d663cb107a0'
+  const isBoletoApiProviderWithoutInterestAndFine =
+    issuer.includes('boleto-api-bradesco-shopfacil')
 
-  const isBoletoApi =
-    issuer.includes('boleto-api') && externalId !== companyCaixaFineAndInterestTestId
-
-  if (isBoletoApi &&
+  if (isBoletoApiProviderWithoutInterestAndFine &&
     (!isEmptyOrNull(interest) || !isEmptyOrNull(fine))) {
     const config = {
       issuer: 'bradesco',

--- a/test/integration/boleto/create/boleto-api-caixa/refused.js
+++ b/test/integration/boleto/create/boleto-api-caixa/refused.js
@@ -39,7 +39,7 @@ test.after(async () => {
   })
 })
 
-test.skip('creates a boleto (status refused)', async (t) => {
+test('creates a boleto (status refused)', async (t) => {
   const payload = mock
 
   payload.issuer = 'boleto-api-caixa'

--- a/test/integration/boleto/create/boleto-api-caixa/registered.js
+++ b/test/integration/boleto/create/boleto-api-caixa/registered.js
@@ -42,7 +42,7 @@ test.after(async () => {
   })
 })
 
-test.skip('creates a boleto (status success)', async (t) => {
+test('creates a boleto (status success)', async (t) => {
   const payload = mock
 
   payload.issuer = 'boleto-api-caixa'

--- a/test/unit/lib/helper/providers.js
+++ b/test/unit/lib/helper/providers.js
@@ -281,7 +281,7 @@ test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and i
   t.is(result.issuer_wallet, '25')
 })
 
-test.skip('changeIssuerWhenInterestOrFine: when interest is null, fine has info and is boleto-api-caixa', async (t) => {
+test('changeIssuerWhenInterestOrFine: when interest is null, fine has info and is boleto-api-caixa', async (t) => {
   const boleto = createFakeBoletoCaixa({ interest: null })
 
   const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')
@@ -292,7 +292,7 @@ test.skip('changeIssuerWhenInterestOrFine: when interest is null, fine has info 
   t.is(result.issuer_wallet, boleto.issuer_wallet)
 })
 
-test.skip('changeIssuerWhenInterestOrFine: when fine is null, interest has info and is boleto-api-caixa', async (t) => {
+test('changeIssuerWhenInterestOrFine: when fine is null, interest has info and is boleto-api-caixa', async (t) => {
   const boleto = createFakeBoletoCaixa({ fine: null })
 
   const result = changeIssuerWhenInterestOrFine(boleto, 'randomOperationId')


### PR DESCRIPTION
## Description

### Tarefa [BPROC-390](https://mundipagg.atlassian.net/browse/BPROC-390) 

Em continuação ao PR [BPROC-390 - implements interest and fine to provider Caixa](https://github.com/pagarme/superbowleto/pull/369), esse PR tem o objetivo de remover a trava abrindo o registro de boletos caixa com juros e multa pela a BoletoAPI para todas as companies. 

