### PR TITLE
[BPROC-418]-Remove buyer address when address is equal to pagarme or company

### DIFF
--- a/src/resources/boleto/model.js
+++ b/src/resources/boleto/model.js
@@ -97,8 +97,8 @@ const addBoletoCode = (boleto) => {
   })
 }
 
-const validateModel = (boleto) => {
-  const defaultAddress = {
+const getPagarmeAddress = () => (
+  {
     zipcode: '04551010',
     street: 'Rua Fidêncio Ramos',
     street_number: '308',
@@ -107,6 +107,10 @@ const validateModel = (boleto) => {
     city: 'São Paulo',
     state: 'SP',
   }
+)
+
+const validateModel = (boleto) => {
+  const defaultAddress = getPagarmeAddress()
 
   const requiredAddressFields = [
     'zipcode',
@@ -319,4 +323,5 @@ module.exports = {
   buildModelResponse,
   validateModel,
   create,
+  getPagarmeAddress,
 }


### PR DESCRIPTION
## Description

Este PR remove o campo endereço do buyer no request para a boleto-api quando o endereço é substituído pelo endereço do pagarme ou for o mesmo da company.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
