### PR TITLE
[BPROC-679] Adjust timeout with Caixa integration

### DIFF
--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -167,7 +167,7 @@ const getInstructions = (companyName, companyDocument, boleto) => {
 
   instructions += ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - ` +
   `CNPJ: ${companyDocument}. Para confirmar a existência deste boleto consulte em pagar.me/boletos`
-  
+
   return instructions
 }
 

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -165,8 +165,9 @@ const defineFees = (boleto) => {
 const getInstructions = (companyName, companyDocument, boleto) => {
   let instructions = path(['instructions'], boleto) || ''
 
-  instructions += ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - CNPJ: ${companyDocument}. Para confirmar a existência deste boleto consulte em pagar.me/boletos`
-
+  instructions += ` A emissão deste boleto foi solicitada e/ou intermediada pela empresa ${companyName} - ` +
+  `CNPJ: ${companyDocument}. Para confirmar a existência deste boleto consulte em pagar.me/boletos`
+  
   return instructions
 }
 
@@ -178,7 +179,7 @@ const buildPayload = (boleto, operationId) => {
 
   const instructions = getInstructions(companyName, companyDocument, boleto)
 
-  const payload = {
+  return {
     bankNumber: caixaBankCode,
     agreement: {
       agreementNumber,
@@ -226,8 +227,6 @@ const buildPayload = (boleto, operationId) => {
     },
     requestKey: operationId,
   }
-
-  return payload
 }
 
 const sendRequestToBoletoApi = async (payload, headers) => {

--- a/src/providers/boleto-api-caixa/index.js
+++ b/src/providers/boleto-api-caixa/index.js
@@ -231,7 +231,7 @@ const buildPayload = (boleto, operationId) => {
 }
 
 const sendRequestToBoletoApi = async (payload, headers) => {
-  const timeoutMs = getRequestTimeoutMs(10000)
+  const timeoutMs = getRequestTimeoutMs(20000)
 
   const axiosPayload = {
     data: payload,


### PR DESCRIPTION
## Description

### Tarefa [BRPOC-679](https://mundipagg.atlassian.net/browse/BPROC-679)

Atualmente, a superbowleto espera por 10s a resposta da boleto-api na integração com a Caixa para o registro de boletos. Após esse tempo, a superbowleto corta a conexão e salva o status do boleto como refused, assumindo que o boleto não foi registrado. Ocorreu alguns casos em que a boleto-api registrou o boleto após a conexão ser rompida, em um tempo médio de 16s, o que gera uma inconsistência entre as duas aplicações. 
Este PR visa aumentar o tempo de espera de 10s para 20s, o que, em tese, irá reduzir a quantidade de ocorrências desse tipo.

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
2. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
3. My changes are well covered by **tests** and **logs**
4. I've updated the project docs (if needed)
5. I feel safe about this implementation
6. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
