### PR TITLE
[BPROC-321] Falha no registro do boleto com caracteres especiais

### DIFF
--- a/src/resources/boleto/schema.js
+++ b/src/resources/boleto/schema.js
@@ -1,6 +1,8 @@
 const Joi = require('joi')
 
 const maximumDateForBarcodeCalculation = '02-22-2025'
+// eslint-disable-next-line
+const specialCharactersReplacement = /[^\x00-\xFF]/g
 
 const createSchema = {
   queue_url: Joi
@@ -141,6 +143,7 @@ const createSchema = {
     .string()
     .allow(null)
     .allow('')
+    .when('issuer', { is: 'bradesco', then: Joi.string().normalize('NFKC').replace(specialCharactersReplacement, '') })
     .when('register', { is: true, then: Joi.required().disallow(null).disallow('') }),
 
   payer_document_type: Joi

--- a/test/unit/resources/boleto/schema.js
+++ b/test/unit/resources/boleto/schema.js
@@ -1,0 +1,87 @@
+import test from 'ava'
+import { parse } from '../../../../src/lib/http/request'
+
+const { createSchema } = require('../../../../src/resources/boleto/schema')
+
+function createMockedSchema () {
+  return {
+    payer_name: 'Teste da Silva',
+    issuer: 'bradesco',
+    queue_url: 'https://pruu.herokuapp.com/dump/super-bowleto-postback',
+    expiration_date: '2022-12-12',
+    amount: 2000,
+    issuer_account: '469',
+    issuer_agency: '1229',
+    issuer_wallet: '29',
+    payer_document_type: 'cpf',
+    payer_document_number: '98154524872',
+  }
+}
+
+function createExpectedObject () {
+  return {
+    payer_name: 'Teste da Silva',
+    issuer: 'bradesco',
+    queue_url: 'https://pruu.herokuapp.com/dump/super-bowleto-postback',
+    expiration_date: new Date('2022-12-12 00:00:00'),
+    amount: 2000,
+    issuer_account: '469',
+    issuer_agency: '1229',
+    issuer_wallet: '29',
+    payer_document_type: 'cpf',
+    payer_document_number: '98154524872',
+    register: true,
+  }
+}
+
+test('sanitizePayerName: when issuer is Bradesco with special characters that should be sanitized', async (t) => {
+  const mockedSchema = createMockedSchema()
+  mockedSchema.payer_name = '𝑱𝒆𝒔𝒔𝒊𝒄𝒂⁶ Ⓨ︎Ⓞ︎Ⓛ︎Ⓐ︎Ⓝ︎Ⓓ︎Ⓞ︎ ⅒ 𝒅𝒂 Silva'
+  mockedSchema.issuer = 'bradesco'
+
+  const testExpectedObject = createExpectedObject()
+  testExpectedObject.payer_name = 'Jessica6 YOLANDO 110 da Silva'
+  const value = await parse(createSchema, mockedSchema)
+
+  t.deepEqual(value, testExpectedObject, 'should have the correct parsed, coerced parameters and no errors')
+})
+
+test('sanitizePayerName: when issuer is Bradesco with special characters that should be kept', async (t) => {
+  const mockedSchema = createMockedSchema()
+  mockedSchema.payer_name = 'João & José $$ (#2022*) @ LTDA ABCDEFGHIJKLMNOPQRSTUVXYWZabcdefghijklmnopqrstuvxyz ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕáéíóúàèìòùâêîôûãõçÇ 0123456789'
+  mockedSchema.issuer = 'bradesco'
+
+  const testExpectedObject = createExpectedObject()
+  testExpectedObject.payer_name = 'João & José $$ (#2022*) @ LTDA ABCDEFGHIJKLMNOPQRSTUVXYWZabcdefghijklmnopqrstuvxyz ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕáéíóúàèìòùâêîôûãõçÇ 0123456789'
+  const value = await parse(createSchema, mockedSchema)
+
+  t.deepEqual(value, testExpectedObject, 'should have the correct parsed, coerced parameters and no errors')
+})
+
+test('sanitizePayerName: when using wrong issuer should NOT sanitize', async (t) => {
+  const mockedSchema = createMockedSchema()
+  mockedSchema.payer_name = 'Ⓨ︎Ⓞ︎Ⓛ︎Ⓐ︎Ⓝ︎Ⓓ︎Ⓞ︎'
+  mockedSchema.issuer = 'boleto-api-caixa'
+
+  const testExpectedObject = createExpectedObject()
+  testExpectedObject.payer_name = 'Ⓨ︎Ⓞ︎Ⓛ︎Ⓐ︎Ⓝ︎Ⓓ︎Ⓞ︎'
+  testExpectedObject.issuer = 'boleto-api-caixa'
+
+  const value = await parse(createSchema, mockedSchema)
+
+  t.deepEqual(value, testExpectedObject, 'should have the correct parsed, coerced parameters and no errors')
+})
+
+test('sanitizePayerName: when using wrong-like issuer should NOT sanitize', async (t) => {
+  const mockedSchema = createMockedSchema()
+  mockedSchema.payer_name = 'Ⓨ︎Ⓞ︎Ⓛ︎Ⓐ︎Ⓝ︎Ⓓ︎Ⓞ︎'
+  mockedSchema.issuer = 'boleto-api-bradesco-shopfacil'
+
+  const testExpectedObject = createExpectedObject()
+  testExpectedObject.payer_name = 'Ⓨ︎Ⓞ︎Ⓛ︎Ⓐ︎Ⓝ︎Ⓓ︎Ⓞ︎'
+  testExpectedObject.issuer = 'boleto-api-bradesco-shopfacil'
+
+  const value = await parse(createSchema, mockedSchema)
+
+  t.deepEqual(value, testExpectedObject, 'should have the correct parsed, coerced parameters and no errors')
+})


### PR DESCRIPTION
# Descrição
### Tarefa [BPROC-321](https://mundipagg.atlassian.net/browse/BPROC-321)

Aplicado sanitização no campo `payer_name` que estava causando  a falha no registro do boleto Bradesco.
 
### Alterações existentes no PR:

- [ ] :ambulance: Correção de um bug crítico;
- [x] :bug: Correção de bug;
- [ ] :sparkles: Nova feature; 
- [ ] :fire: Remoção de funcionalidade ou arquivos;
- [ ] :recycle: Refatoração;
- [ ] :art: Formatação;
- [ ] :zap: Performance;
- [ ] :memo: Documentação;
- [ ] :speaker: Logs;
- [ ] :wrench: Arquivos de configuração;
- [ ] :poop: Ajuste temporário.

## Checklist

- [x] Associei corretamente à Tarefa do Board ao Pull Request;
- [x] Meu código segue as diretrizes desse projeto;
- [x] Eu revisei meu próprio código;
- [x] Eu comentei meu código em áreas particulares de difícil compreensão;
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas;
- [x] Meu código não gerou novos warnings;
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona;
- [x] Testes novos e existentes passam localmente com minhas alterações; 
- [ ] Testes novos e existentes passam em staging com minhas alterações; 
- [ ] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, tarefa de banco de dados, etc);