### PR TITLE
BPROC-819 - Remover limitação de data de expiração para o issuer development

### DIFF
--- a/src/resources/boleto/schema.js
+++ b/src/resources/boleto/schema.js
@@ -1,6 +1,6 @@
 const Joi = require('joi')
 
-const maximumDateForBarcodeCalculation = '02-22-2025'
+const maximumDateForBarcodeCalculation = '2025-02-22T23:59:59.000Z'
 // eslint-disable-next-line
 const specialCharactersReplacement = /[^\x00-\xFF]/g
 
@@ -10,7 +10,8 @@ const createSchema = {
     .required(),
 
   expiration_date: Joi
-    .when('issuer', { is: 'boleto-api-caixa', then: Joi.date(), otherwise: Joi.date().max(maximumDateForBarcodeCalculation) })
+    .date()
+    .when('issuer', { is: ['boleto-api-bradesco-shopfacil', 'bradesco'], then: Joi.date().max(maximumDateForBarcodeCalculation) })
     .required(),
 
   amount: Joi

--- a/test/functional/boletos/create.js
+++ b/test/functional/boletos/create.js
@@ -147,7 +147,7 @@ test('POST /boletos with invalid expiration_date', async (t) => {
     errors: [
       {
         type: 'invalid_parameter',
-        message: '"expiration_date" must be less than or equal to "Sat Feb 22 2025 00:00:00 GMT+0000 (UTC)"',
+        message: '"expiration_date" must be less than or equal to "Sat Feb 22 2025 23:59:59 GMT+0000 (UTC)"',
         field: 'expiration_date',
       },
     ],

--- a/test/unit/resources/boleto/schema.js
+++ b/test/unit/resources/boleto/schema.js
@@ -38,7 +38,7 @@ function createExpectedObject (date = '2024-02-23 00:00:00') {
 function expirationDateErrorFactory () {
   return new InvalidParameterError({
     type: 'invalid_parameter',
-    message: '"expiration_date" must be less than or equal to "Sat Feb 22 2025 00:00:00 GMT+0000 (UTC)"',
+    message: '"expiration_date" must be less than or equal to "Sat Feb 22 2025 23:59:59 GMT+0000 (UTC)"',
     field: 'expiration_date',
   })
 }
@@ -69,8 +69,15 @@ test('Expiration date limit - when issuer is boleto-api-bradesco-shopfacil and e
 })
 
 test('Expiration date limit - when issuer is boleto-api-caixa and expiration-date greater than 2025-02-22, should not return erros', async (t) => {
-  const mockedSchema = createMockedSchema()
+  const mockedSchema = createMockedSchema('2025-02-23')
   mockedSchema.issuer = 'boleto-api-caixa'
+
+  await t.notThrows(async () => parse(createSchema, mockedSchema))
+})
+
+test('Expiration date limit - when issuer is development and expiration-date greater than 2025-02-22, should not return erros', async (t) => {
+  const mockedSchema = createMockedSchema('2025-02-23')
+  mockedSchema.issuer = 'development'
 
   await t.notThrows(async () => parse(createSchema, mockedSchema))
 })


### PR DESCRIPTION
## Description

### [Tarefa BPROC-819](https://mundipagg.atlassian.net/browse/BPROC-819)

O intuito desse PR é remover a trava de limitação de data de expiração para o issuer de development. Além disso, corrige a data limite para o fim do dia 22-02-2025, às 23h59, ao invés de para o início do dia (00h). 

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
2. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
3. My changes are well covered by **tests** and **logs**
4. I've updated the project docs (if needed)
5. I fell safe about this implementation
6. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
