### PR TITLE
[BPROC-1285] Ajustar Keep Alive Timeout e Headers Timeout

### DIFF
--- a/src/bin/server.js
+++ b/src/bin/server.js
@@ -9,18 +9,32 @@ const database = require('../database')
 const { ensureDatabaseIsConnected } = require('../functions/database')
 const application = require('../server')
 const { setupGracefulShutdown } = require('../server/shutdown')
+const { makeLogger } = require('../lib/logger')
 
 const { PORT = 3000 } = process.env
 
-const startServer = app => app.listen(PORT)
+const startServer = (app) => {
+  const server = app.listen(PORT)
+
+  server.keepAliveTimeout = 65 * 1000
+  server.headersTimeout = 66 * 1000
+
+  return server
+}
 
 const handleInitializationErrors = (err) => {
-  if (err instanceof DatabaseError) {
-    console.log(`Initialization failed with connection to database: ${err}`)
-    return process.exit(1)
-  }
+  const logger = makeLogger()
+  const isDatabaseError = err instanceof DatabaseError
 
-  console.log(`Unknown error: ${err}`)
+  logger.error({
+    message: 'Initialization failed',
+    metadata: {
+      error_message: err.message,
+      error_description: isDatabaseError ? 'Error on database connection' : 'Unknown error',
+      error_stack: err.stack ? err.stack.split('\n') : null,
+    },
+  })
+
   return process.exit(1)
 }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,7 +20,6 @@ const {
 const app = express()
 const allRoutesExceptHealthCheck = /^\/(?!_health_check(\/|$)).*$/i
 
-
 app.use(bodyParser.json())
 
 app.disable('x-powered-by')
@@ -39,9 +38,5 @@ app.patch('/configurations/:id', updateConfig)
 app.get('/configurations/:external_id', showConfig)
 
 app.all('*', defaultResourceHandler)
-
-app.headersTimeout = 65 * 1000
-app.keepAliveTimeout = 61 * 1000
-app.timeout = 60 * 1000
 
 module.exports = app


### PR DESCRIPTION
## Description

Hoje em algumas requisições entre o pagarme-gateway e a superbowleto, temos um erro onde o pagarme-gateway recebe erro 502 conforme podemos ver nessa [query](https://app.datadoghq.com/logs?query=service%3Apagarme-gateway%20%40metadata.statusCode%3A5%2A%20Superbowleto%20error%20for%20transaction%20%40dd.env%3Aproduction%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1687219042536&to_ts=1688515042536&live=true). Há um tempo atrás tínhamos esse problema também na aplicação PIX, onde a configuração de Keep Alive Timeout estava incorreta no webserver do PIX e com isso fazia com que o servidor encerrasse uma conexão, e posteriormente o client tentava usar essa conexão já encerrada, e recebia o erro 502.

- Corrige a configuração do keep Alive timeout
- Corrige o headers timeout

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
2. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
3. My changes are well covered by **tests** and **logs**
4. I've updated the project docs (if needed)
5. I fell safe about this implementation
6. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:
